### PR TITLE
Support Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ SCIM defines a flexible schema mechanism and REST API for managing identity data
 The goal is to reduce the complexity of user management operations by providing patterns for exchanging schemas using HTTP.
 
 In this implementation it is easy to add *custom* schemas and extensions whom are validated at the initialization of the server.
-Corresponding with their resource type, incoming resources will be *validated* by the supported schemas before being 
+Corresponding with their resource type, incoming resources will be *validated* by the supported schemas before being
 passed on to their callbacks.
 
 The following features are supported:
 - GET for `/Schemas`, `/ServiceProviderConfig` and `/ResourceTypes`
 - CRUD (POST/GET/PUT and DELETE) for your own resource types (i.e. `/Users`, `/Groups`, `/Employees`, ...)
 
-Other optional features such as patch, pagination, sorting, etc... are **not** supported in this version.
+Other optional features such as patch, filtering, sorting, etc... are **not** supported in this version.
 
 ## Installation
 Assuming you already have a (recent) version of Go installed, you can get the code with go get:
@@ -111,8 +111,8 @@ log.Fatal(http.ListenAndServe(":8080", server))
 ```
 
 ## Contributing
-We are happy to review pull requests, 
-but please first discuss the change you wish to make via issue, email, 
+We are happy to review pull requests,
+but please first discuss the change you wish to make via issue, email,
 or any other method with the owners of this repository before making a change.
 
 If you’d like to propose a change please ensure the following:
@@ -120,7 +120,7 @@ If you’d like to propose a change please ensure the following:
 - all already existing tests are passing
 - you have written tests that cover the code you are making
 - there is documentation for at least all public functions you have added
-- your changes are compliant with SCIM v2.0 (released as 
-[RFC7642](https://tools.ietf.org/html/rfc7642), 
-[RFC7643](https://tools.ietf.org/html/rfc7643) and 
+- your changes are compliant with SCIM v2.0 (released as
+[RFC7642](https://tools.ietf.org/html/rfc7642),
+[RFC7643](https://tools.ietf.org/html/rfc7643) and
 [RFC7644](https://tools.ietf.org/html/rfc7644) under [IETF](https://ietf.org/))

--- a/error.go
+++ b/error.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/elimity-com/scim/errors"
 )
@@ -28,6 +29,23 @@ func scimErrorResourceNotFound(id string) scimError {
 	return scimError{
 		detail: fmt.Sprintf("Resource %s not found.", id),
 		status: http.StatusNotFound,
+	}
+}
+
+func scimErrorBadRequest(invalidParams []string) scimError {
+	var suffix string
+
+	if len(invalidParams) > 1 {
+		suffix = "s"
+	}
+
+	return scimError{
+		detail: fmt.Sprintf(
+			"Bad Request. Invalid parameter%s provided in request: %s.",
+			suffix,
+			strings.Join(invalidParams, ", "),
+		),
+		status: http.StatusBadRequest,
 	}
 }
 
@@ -110,6 +128,13 @@ func scimGetError(getError errors.GetError, id string) scimError {
 	switch getError {
 	case errors.GetErrorResourceNotFound:
 		return scimErrorResourceNotFound(id)
+	default:
+		return scimErrorInternalServer
+	}
+}
+
+func scimGetAllError(getError errors.GetError) scimError {
+	switch getError {
 	default:
 		return scimErrorInternalServer
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/elimity-com/scim
 
 go 1.13
 
-require github.com/di-wu/xsd-datetime v0.0.0-20190813080539-55a8ba70aa69
+require (
+	github.com/di-wu/scim-filter-parser v0.0.0-20190602150935-cdaa38509d09
+	github.com/di-wu/xsd-datetime v0.0.0-20190813080539-55a8ba70aa69
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/di-wu/scim-filter-parser v0.0.0-20190602150935-cdaa38509d09 h1:GYqnpcuwqmben6WKAmtUI9yayGoZf1RnqDzLkbLLuKc=
+github.com/di-wu/scim-filter-parser v0.0.0-20190602150935-cdaa38509d09/go.mod h1:Q9X8NLzgdqI3Z0XcbiPpdAEql664lC6ExBN7B6ZLhco=
 github.com/di-wu/xsd-datetime v0.0.0-20190813080539-55a8ba70aa69 h1:KlIk21PbvrYUBb2Dv2gsd4VZjYviGgevIadTj9ebExU=
 github.com/di-wu/xsd-datetime v0.0.0-20190813080539-55a8ba70aa69/go.mod h1:i3iEhrP3WchwseOBeIdW/zxeoleXTOzx1WyDXgdmOww=

--- a/handlers.go
+++ b/handlers.go
@@ -167,14 +167,17 @@ func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id st
 // resourcesGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users" or "/Groups", to retrieve
 // all known resources.
 func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, resourceType ResourceType, params ListRequestParams) {
-	listResponse, getError := resourceType.Handler.GetAll(params)
+	page, getError := resourceType.Handler.GetAll(params)
 
 	if getError != errors.GetErrorNil {
 		errorHandler(w, r, scimGetAllError(getError))
 		return
 	}
 
-	raw, err := json.Marshal(listResponse.toInternalListResponse(resourceType))
+	raw, err := json.Marshal(
+		page.toInternalListResponse(resourceType, params.StartIndex, params.Count),
+	)
+
 	if err != nil {
 		errorHandler(w, r, scimErrorInternalServer)
 		log.Fatalf("failed marshalling list response: %v", err)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,8 +104,12 @@ func newTestServer() Server {
 
 func newTestResourceHandler() ResourceHandler {
 	data := make(map[string]ResourceAttributes)
-	data["0001"] = ResourceAttributes{
-		"userName": "test",
+
+	// Generate enough test data to test pagination
+	for i := 1; i < 21; i++ {
+		data[fmt.Sprintf("000%d", i)] = ResourceAttributes{
+			"userName": fmt.Sprintf("test%d", i),
+		}
 	}
 
 	return testResourceHandler{
@@ -267,7 +272,7 @@ func TestServerResourcePostHandlerInvalid(t *testing.T) {
 }
 
 func TestServerResourcePostHandlerValid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/Users", strings.NewReader(`{"id": "other", "userName": "test"}`))
+	req := httptest.NewRequest(http.MethodPost, "/Users", strings.NewReader(`{"id": "other", "userName": "test1"}`))
 	rr := httptest.NewRecorder()
 	newTestServer().ServeHTTP(rr, req)
 
@@ -279,7 +284,7 @@ func TestServerResourcePostHandlerValid(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
 		t.Fatal(err)
 	}
-	if resource["userName"] != "test" {
+	if resource["userName"] != "test1" {
 		t.Error("handler did not return the resource correctly")
 	}
 }
@@ -297,7 +302,7 @@ func TestServerResourceGetHandler(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
 		t.Fatal(err)
 	}
-	if resource["userName"] != "test" {
+	if resource["userName"] != "test1" {
 		t.Error("handler did not return the resource correctly")
 	}
 }
@@ -329,13 +334,51 @@ func TestServerResourcesGetHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	var response listResponse
+	var response ListResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
 		t.Error(err)
 	}
 
-	if response.TotalResults != 1 {
-		t.Errorf("handler returned unexpected body: got %v want 1 total result", rr.Body.String())
+	if response.TotalResults != 10 {
+		t.Errorf("handler returned unexpected body: got %v want 10 total result", rr.Body.String())
+	}
+}
+
+func TestServerResourcesGetHandlerPagination(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/Users?count=2&startIndex=2", nil)
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response ListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Error(err)
+	}
+
+	if response.TotalResults != 2 {
+		t.Errorf("handler returned unexpected body: got %v want 2 total result", rr.Body.String())
+	}
+}
+
+func TestServerResourcesGetHandlerMaxCount(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/Users?count=20000", nil)
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var response ListResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Error(err)
+	}
+
+	if response.TotalResults != 20 {
+		t.Errorf("handler returned unexpected body: got %v want 20 total result", rr.Body.String())
 	}
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -334,13 +334,13 @@ func TestServerResourcesGetHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	var response ListResponse
+	var response listResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
 		t.Error(err)
 	}
 
-	if response.TotalResults != 10 {
-		t.Errorf("handler returned unexpected body: got %v want 10 total result", rr.Body.String())
+	if response.TotalResults != 20 {
+		t.Errorf("handler returned unexpected body: got %v want 20 total result", response.TotalResults)
 	}
 }
 
@@ -353,13 +353,13 @@ func TestServerResourcesGetHandlerPagination(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	var response ListResponse
+	var response listResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
 		t.Error(err)
 	}
 
-	if response.TotalResults != 2 {
-		t.Errorf("handler returned unexpected body: got %v want 2 total result", rr.Body.String())
+	if response.TotalResults != 20 {
+		t.Errorf("handler returned unexpected body: got %v want 20 total result", response.TotalResults)
 	}
 }
 
@@ -372,13 +372,13 @@ func TestServerResourcesGetHandlerMaxCount(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	var response ListResponse
+	var response listResponse
 	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
 		t.Error(err)
 	}
 
 	if response.TotalResults != 20 {
-		t.Errorf("handler returned unexpected body: got %v want 20 total result", rr.Body.String())
+		t.Errorf("handler returned unexpected body: got %v want 20 total result", response.TotalResults)
 	}
 }
 

--- a/list_response.go
+++ b/list_response.go
@@ -4,6 +4,26 @@ import (
 	"encoding/json"
 )
 
+// NewListResponse creates a new list response with provided paramters.
+func NewListResponse(resources []Resource, startIndex, totalResults, itemsPerPage int) ListResponse {
+	return ListResponse{
+		TotalResults: totalResults,
+		ItemsPerPage: itemsPerPage,
+		StartIndex:   startIndex,
+		Resources:    resources,
+	}
+}
+
+func (l *ListResponse) toInternalListResponse(resourceType ResourceType) listResponse {
+	convertedResources := make([]interface{}, len(l.Resources))
+
+	for i, res := range l.Resources {
+		convertedResources[i] = res.response(resourceType)
+	}
+
+	return newListResponse(convertedResources)
+}
+
 func newListResponse(resources []interface{}) listResponse {
 	return listResponse{
 		TotalResults: len(resources),
@@ -13,27 +33,51 @@ func newListResponse(resources []interface{}) listResponse {
 	}
 }
 
-// listResponse identifies a query response.
-type listResponse struct {
-	// TotalResults is the total number of results returned by the list or query operation.
-	// The value may be larger than the number of resources returned, such as when returning
-	// a single page of results where multiple pages are available.
-	// REQUIRED
-	TotalResults int
+type (
+	// ListResponse identifies a paginated query response.
+	ListResponse struct {
+		// TotalResults is the total number of results returned by the list or query operation.
+		// The value may be larger than the number of resources returned, such as when returning
+		// a single page of results where multiple pages are available.
+		// REQUIRED
+		TotalResults int
 
-	// ItemsPerPage is the number of resources returned in a list response page.
-	// REQUIRED when partial results are returned due to pagination.
-	ItemsPerPage int
+		// ItemsPerPage is the number of resources returned in a list response page.
+		// REQUIRED when partial results are returned due to pagination.
+		ItemsPerPage int
 
-	// StartIndex is a 1-based index of the first result in the current set of the list results.
-	// REQUIRED when partial results are returned due to pagination.
-	StartIndex int
+		// StartIndex is a 1-based index of the first result in the current set of the list results.
+		// REQUIRED when partial results are returned due to pagination.
+		StartIndex int
 
-	// Resources is a multi-valued list of complex objects containing the requested resources.
-	// This may be a subset of the full set of resources if pagination is requested.
-	// REQUIRED if TotalResults is non-zero.
-	Resources []interface{}
-}
+		// Resources is a multi-valued list of complex objects containing the requested resources.
+		// This may be a subset of the full set of resources if pagination is requested.
+		// REQUIRED if TotalResults is non-zero.
+		Resources []Resource
+	}
+
+	// listResponse identifies a query response.
+	listResponse struct {
+		// TotalResults is the total number of results returned by the list or query operation.
+		// The value may be larger than the number of resources returned, such as when returning
+		// a single page of results where multiple pages are available.
+		// REQUIRED
+		TotalResults int
+
+		// ItemsPerPage is the number of resources returned in a list response page.
+		// REQUIRED when partial results are returned due to pagination.
+		ItemsPerPage int
+
+		// StartIndex is a 1-based index of the first result in the current set of the list results.
+		// REQUIRED when partial results are returned due to pagination.
+		StartIndex int
+
+		// Resources is a multi-valued list of complex objects containing the requested resources.
+		// This may be a subset of the full set of resources if pagination is requested.
+		// REQUIRED if TotalResults is non-zero.
+		Resources []interface{}
+	}
+)
 
 func (l listResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{

--- a/list_response.go
+++ b/list_response.go
@@ -4,24 +4,27 @@ import (
 	"encoding/json"
 )
 
-// NewListResponse creates a new list response with provided paramters.
-func NewListResponse(resources []Resource, startIndex, totalResults, itemsPerPage int) ListResponse {
-	return ListResponse{
+// NewPage creates a new list response with provided paramters.
+func NewPage(resources []Resource, totalResults int) Page {
+	return Page{
 		TotalResults: totalResults,
-		ItemsPerPage: itemsPerPage,
-		StartIndex:   startIndex,
 		Resources:    resources,
 	}
 }
 
-func (l *ListResponse) toInternalListResponse(resourceType ResourceType) listResponse {
-	convertedResources := make([]interface{}, len(l.Resources))
+func (p Page) toInternalListResponse(resourceType ResourceType, startIndex, itemsPerPage int) listResponse {
+	convertedResources := make([]interface{}, len(p.Resources))
 
-	for i, res := range l.Resources {
+	for i, res := range p.Resources {
 		convertedResources[i] = res.response(resourceType)
 	}
 
-	return newListResponse(convertedResources)
+	return listResponse{
+		TotalResults: p.TotalResults,
+		Resources:    convertedResources,
+		StartIndex:   startIndex,
+		ItemsPerPage: itemsPerPage,
+	}
 }
 
 func newListResponse(resources []interface{}) listResponse {
@@ -34,25 +37,11 @@ func newListResponse(resources []interface{}) listResponse {
 }
 
 type (
-	// ListResponse identifies a paginated query response.
-	ListResponse struct {
+	// Page represents a paginated resource query response.
+	Page struct {
 		// TotalResults is the total number of results returned by the list or query operation.
-		// The value may be larger than the number of resources returned, such as when returning
-		// a single page of results where multiple pages are available.
-		// REQUIRED
 		TotalResults int
-
-		// ItemsPerPage is the number of resources returned in a list response page.
-		// REQUIRED when partial results are returned due to pagination.
-		ItemsPerPage int
-
-		// StartIndex is a 1-based index of the first result in the current set of the list results.
-		// REQUIRED when partial results are returned due to pagination.
-		StartIndex int
-
 		// Resources is a multi-valued list of complex objects containing the requested resources.
-		// This may be a subset of the full set of resources if pagination is requested.
-		// REQUIRED if TotalResults is non-zero.
 		Resources []Resource
 	}
 

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -7,17 +7,31 @@ import (
 	"github.com/elimity-com/scim/errors"
 )
 
-// ResourceAttributes represents a list of attributes given to the callback method to create or replace a resource based
-// on the given attributes.
-type ResourceAttributes map[string]interface{}
+type (
+	// ListRequestParams request parameters sent to the API via the "GetAll" route.
+	ListRequestParams struct {
+		// Count specifies the desired maximum number of query results per page. A negative value
+		// SHALL be interpreted as "0". A value of "0" indicates that no resource
+		// results are to be returned except for "totalResults".
+		Count int
 
-// Resource represents an entity returned by a callback method.
-type Resource struct {
-	// ID is the unique identifier created by the callback method "Create".
-	ID string
-	// Attributes is a list of attributes defining the resource.
-	Attributes ResourceAttributes
-}
+		// StartIndex The 1-based index of the first query result.
+		// A value less than 1 SHALL be interpreted as 1.
+		StartIndex int
+	}
+
+	// ResourceAttributes represents a list of attributes given to the callback method to create or replace
+	// a resource based on the given attributes.
+	ResourceAttributes map[string]interface{}
+
+	// Resource represents an entity returned by a callback method.
+	Resource struct {
+		// ID is the unique identifier created by the callback method "Create".
+		ID string
+		// Attributes is a list of attributes defining the resource.
+		Attributes ResourceAttributes
+	}
+)
 
 func (r Resource) response(resourceType ResourceType) ResourceAttributes {
 	response := r.Attributes
@@ -41,8 +55,8 @@ type ResourceHandler interface {
 	Create(attributes ResourceAttributes) (Resource, errors.PostError)
 	// Get returns the resource corresponding with the given identifier.
 	Get(id string) (Resource, errors.GetError)
-	// GetAll returns all the resources.
-	GetAll() []Resource
+	// GetAll returns a paginated list of resources.
+	GetAll(params ListRequestParams) (ListResponse, errors.GetError)
 	// Replace replaces ALL existing attributes of the resource with given identifier. Given attributes that are empty
 	// are to be deleted. Returns a resource with the attributes that are stored.
 	Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError)

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	scim "github.com/di-wu/scim-filter-parser"
 	"github.com/elimity-com/scim/errors"
 )
 
@@ -14,6 +15,11 @@ type (
 		// SHALL be interpreted as "0". A value of "0" indicates that no resource
 		// results are to be returned except for "totalResults".
 		Count int
+
+		// Filter represents the parsed and tokenized filter query parameter. It is an optional param
+		// and thus will be nil when the param is not present.
+		// https://github.com/di-wu/scim-filter-parser
+		Filter scim.Expression
 
 		// StartIndex The 1-based index of the first query result.
 		// A value less than 1 SHALL be interpreted as 1.
@@ -56,7 +62,7 @@ type ResourceHandler interface {
 	// Get returns the resource corresponding with the given identifier.
 	Get(id string) (Resource, errors.GetError)
 	// GetAll returns a paginated list of resources.
-	GetAll(params ListRequestParams) (ListResponse, errors.GetError)
+	GetAll(params ListRequestParams) (Page, errors.GetError)
 	// Replace replaces ALL existing attributes of the resource with given identifier. Given attributes that are empty
 	// are to be deleted. Returns a resource with the attributes that are stored.
 	Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError)

--- a/resource_handler_test.go
+++ b/resource_handler_test.go
@@ -49,7 +49,7 @@ func (h testResourceHandler) Get(id string) (Resource, errors.GetError) {
 	}, errors.GetErrorNil
 }
 
-func (h testResourceHandler) GetAll(params ListRequestParams) (ListResponse, errors.GetError) {
+func (h testResourceHandler) GetAll(params ListRequestParams) (Page, errors.GetError) {
 	resources := make([]Resource, 0)
 	i := 1
 
@@ -67,7 +67,7 @@ func (h testResourceHandler) GetAll(params ListRequestParams) (ListResponse, err
 		i++
 	}
 
-	return NewListResponse(resources, params.StartIndex, len(h.data), params.Count), errors.GetErrorNil
+	return NewPage(resources, len(h.data)), errors.GetErrorNil
 }
 
 func (h testResourceHandler) Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError) {

--- a/resource_handler_test.go
+++ b/resource_handler_test.go
@@ -49,18 +49,25 @@ func (h testResourceHandler) Get(id string) (Resource, errors.GetError) {
 	}, errors.GetErrorNil
 }
 
-func (h testResourceHandler) GetAll() []Resource {
-	// get all existing resources
-	all := make([]Resource, 0)
+func (h testResourceHandler) GetAll(params ListRequestParams) (ListResponse, errors.GetError) {
+	resources := make([]Resource, 0)
+	i := 1
+
 	for k, v := range h.data {
-		all = append(all, Resource{
-			ID:         k,
-			Attributes: v,
-		})
+		if i > (params.StartIndex + params.Count - 1) {
+			break
+		}
+
+		if i >= params.StartIndex {
+			resources = append(resources, Resource{
+				ID:         k,
+				Attributes: v,
+			})
+		}
+		i++
 	}
 
-	// return all resources
-	return all
+	return NewListResponse(resources, params.StartIndex, len(h.data), params.Count), errors.GetErrorNil
 }
 
 func (h testResourceHandler) Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError) {

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -14,6 +14,8 @@ type ServiceProviderConfig struct {
 	DocumentationURI optional.String
 	// AuthenticationSchemes is a multi-valued complex type that specifies supported authentication scheme properties.
 	AuthenticationSchemes []AuthenticationScheme
+	// ItemsPerPage denotes the maximum and default count on a list request. It defaults to 100.
+	ItemsPerPage int
 }
 
 // AuthenticationScheme specifies a supported authentication scheme property.
@@ -64,7 +66,7 @@ func (config ServiceProviderConfig) MarshalJSON() ([]byte, error) {
 		},
 		"filter": map[string]interface{}{
 			"supported":  false,
-			"maxResults": 200,
+			"maxResults": config.ItemsPerPage,
 		},
 		"changePassword": map[string]bool{
 			"supported": false,
@@ -77,6 +79,15 @@ func (config ServiceProviderConfig) MarshalJSON() ([]byte, error) {
 		},
 		"authenticationSchemes": getRawAuthSchemes(config.AuthenticationSchemes),
 	})
+}
+
+// GetItemsPerPage retrieves the configured default count. It falls back to 100 when not configured.
+func (config ServiceProviderConfig) GetItemsPerPage() int {
+	if config.ItemsPerPage < 1 {
+		return fallbackCount
+	}
+
+	return config.ItemsPerPage
 }
 
 func getRawAuthSchemes(arr []AuthenticationScheme) []map[string]interface{} {


### PR DESCRIPTION
Implementing pagination by changing the `GetAll` signature to take `ListRequestParams`, and return a `ListResponse` and a `errors.GetError`. This breaks the current API interface but since this is still in Alpha I think that is OK, even without a major version bump. 

* The `count` param defaults to a hardcoded `10` and is maxed out at 200 (see question below)
* The `startIndex` defaults to `1` per the spec

## Questions

* Should there be a configurable default and max for `count`? I was considering exposing it on the `ServiceProviderConfig`, thoughts?