### PR TITLE
PATCH Support

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -11,6 +11,24 @@ const (
 	GetErrorResourceNotFound
 )
 
+// PatchError represents an error that is returned by a PATCH HTTP request.
+type PatchError int
+
+const (
+	// PatchErrorNil indicates that no error occurred during handling a PUT HTTP request.
+	PatchErrorNil PatchError = iota
+	// PatchErrorUniqueness shall be returned when one or more of the attribute values are already in use or are reserved.
+	PatchErrorUniqueness
+	// PatchErrorMutability shall be returned when the attempted modification is not compatible with the target
+	// attribute's mutability or current state.
+	PatchErrorMutability
+	// PatchErrorResourceNotFound returns an error with status code 404 and a human readable message containing the
+	// identifier of the resource that was requested to be replaced but not found.
+	PatchErrorResourceNotFound
+	// PatchErrorNotImplemented allows consumers to create a patch handler that simply returns an unsupported error.
+	PatchErrorNotImplemented
+)
+
 // PostError represents an error that is returned by a POST HTTP request.
 type PostError int
 

--- a/patch_operation.go
+++ b/patch_operation.go
@@ -1,0 +1,60 @@
+package scim
+
+import (
+	"strings"
+
+	scim "github.com/di-wu/scim-filter-parser"
+)
+
+const (
+	add     = "add"
+	remove  = "remove"
+	replace = "replace"
+)
+
+var (
+	validOps = []string{add, remove, replace}
+)
+
+type (
+	// PatchOperation represents a single PATCH operation.
+	PatchOperation struct {
+		Op    string      `json:"op"`
+		Path  string      `json:"path"`
+		Value interface{} `json:"value,omitempty"`
+	}
+
+	// PatchRequest represents a resource PATCH request.
+	PatchRequest struct {
+		Schemas    []string         `json:"schemas"`
+		Operations []PatchOperation `json:"Operations"`
+	}
+)
+
+// HasPathFilter whether or not the path in the operation is in filter syntax or not.
+// ex:
+// "emails[type eq \"work\" and value ew \"example.com\"]" -> true
+// "emails"                                                -> false
+func (p PatchOperation) HasPathFilter() bool {
+	return p.GetPathFilter() != nil
+}
+
+// GetPathFilter parses patch operation path to determine if it is a filter. If it is, scim.Expression will be returned
+// if it is not, it will be nil.
+func (p PatchOperation) GetPathFilter() *scim.AttributeExpression {
+	parser := scim.NewParser(strings.NewReader(p.Path))
+	filter, err := parser.Parse()
+
+	// We can assume the path provided is not a filter
+	if err != nil {
+		return nil
+	}
+
+	// Only attribute expressions are supported with PATCH paths
+	// PATH = attrPath / valuePath [subAttr]
+	if attrFilter, ok := filter.(scim.AttributeExpression); ok {
+		return &attrFilter
+	}
+
+	return nil
+}

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -68,4 +68,7 @@ type ResourceHandler interface {
 	Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError)
 	// Delete removes the resource with corresponding ID.
 	Delete(id string) errors.DeleteError
+	// Patch update one or more attributes of a SCIM resource using a sequence of
+	// operations to "add", "remove", or "replace" values.
+	Patch(id string, request PatchRequest) (Resource, errors.PatchError)
 }

--- a/server.go
+++ b/server.go
@@ -89,6 +89,9 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			case http.MethodPut:
 				s.resourcePutHandler(w, r, id, resourceType)
 				return
+			case http.MethodPatch:
+				s.resourcePatchHandler(w, r, id, resourceType)
+				return
 			case http.MethodDelete:
 				s.resourceDeleteHandler(w, r, id, resourceType)
 				return
@@ -139,7 +142,7 @@ func (s Server) parseRequestParams(r *http.Request) (ListRequestParams, *scimErr
 	}
 
 	if len(invalidParams) > 1 {
-		err = scimErrorBadRequest(invalidParams)
+		err = scimErrorBadParams(invalidParams)
 
 		return ListRequestParams{}, &err
 	}
@@ -156,7 +159,7 @@ func (s Server) parseRequestParams(r *http.Request) (ListRequestParams, *scimErr
 	filter, filterErr := getFilter(r)
 
 	if filterErr != nil {
-		err = scimErrorBadRequest([]string{"filter"})
+		err = scimErrorBadParams([]string{"filter"})
 
 		return ListRequestParams{}, &err
 	}

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -16,8 +16,10 @@ type ServiceProviderConfig struct {
 	AuthenticationSchemes []AuthenticationScheme
 	// ItemsPerPage denotes the maximum and default count on a list request. It defaults to 100.
 	ItemsPerPage int
-	// SupportsFiltering whether your app supports filtering.
-	SupportsFiltering bool
+	// SupportFiltering whether you SCIM implementation will support filtering.
+	SupportFiltering bool
+	// SupportPatch whether your SCIM implementation will support patch requests.
+	SupportPatch bool
 }
 
 // AuthenticationScheme specifies a supported authentication scheme property.
@@ -59,7 +61,7 @@ func (config ServiceProviderConfig) MarshalJSON() ([]byte, error) {
 		"schemas":          []string{"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"},
 		"documentationUri": config.DocumentationURI.Value(),
 		"patch": map[string]bool{
-			"supported": false,
+			"supported": config.SupportPatch,
 		},
 		"bulk": map[string]interface{}{
 			"supported":      false,
@@ -67,7 +69,7 @@ func (config ServiceProviderConfig) MarshalJSON() ([]byte, error) {
 			"maxPayloadSize": 1048576,
 		},
 		"filter": map[string]interface{}{
-			"supported":  config.SupportsFiltering,
+			"supported":  config.SupportFiltering,
 			"maxResults": config.ItemsPerPage,
 		},
 		"changePassword": map[string]bool{

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,11 @@
+package scim
+
+func contains(arr []string, el string) bool {
+	for _, item := range arr {
+		if item == el {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
* Support PATCH handler function
* Add Filter support for potential path filtering with a small caveat https://github.com/di-wu/scim-filter-parser/issues/1
* Validate PATCH request body

## Questions

* Is it worth doing more in depth validation of operation path filters?
* Would more detailed error responses be worth the effort?  For instance, rather then `body is malformed` (paraphrased), we would return `body is malformed, causes: "thing" is required, "otherThing" is immutable`