### PR TITLE
Expose request to handler functions

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -159,7 +159,7 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	resource, patchErr := resourceType.Handler.Patch(id, patch)
+	resource, patchErr := resourceType.Handler.Patch(r, id, patch)
 	if patchErr != errors.PatchErrorNil {
 		errorHandler(w, r, scimPatchError(patchErr, id))
 		return
@@ -189,7 +189,7 @@ func (s Server) resourcePostHandler(w http.ResponseWriter, r *http.Request, reso
 		return
 	}
 
-	resource, postErr := resourceType.Handler.Create(attributes)
+	resource, postErr := resourceType.Handler.Create(r, attributes)
 	if postErr != errors.PostErrorNil {
 		errorHandler(w, r, scimPostError(postErr))
 		return
@@ -211,7 +211,7 @@ func (s Server) resourcePostHandler(w http.ResponseWriter, r *http.Request, reso
 // resourceGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
 // where "{id}" is a resource identifier to retrieve a known resource.
 func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
-	resource, getErr := resourceType.Handler.Get(id)
+	resource, getErr := resourceType.Handler.Get(r, id)
 	if getErr != errors.GetErrorNil {
 		errorHandler(w, r, scimGetError(getErr, id))
 		return
@@ -238,7 +238,7 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 		return
 	}
 
-	page, getError := resourceType.Handler.GetAll(params)
+	page, getError := resourceType.Handler.GetAll(r, params)
 	if getError != errors.GetErrorNil {
 		errorHandler(w, r, scimGetAllError(getError))
 		return
@@ -277,7 +277,7 @@ func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
-	resource, putError := resourceType.Handler.Replace(id, attributes)
+	resource, putError := resourceType.Handler.Replace(r, id, attributes)
 	if putError != errors.PutErrorNil {
 		errorHandler(w, r, scimPutError(putError, id))
 		return
@@ -298,7 +298,7 @@ func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id st
 // resourceDeleteHandler receives an HTTP DELETE request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
 // where "{id}" is a resource identifier to delete a known resource.
 func (s Server) resourceDeleteHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
-	deleteErr := resourceType.Handler.Delete(id)
+	deleteErr := resourceType.Handler.Delete(r, id)
 	if deleteErr != errors.DeleteErrorNil {
 		errorHandler(w, r, scimDeleteError(deleteErr, id))
 		return

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	scim "github.com/di-wu/scim-filter-parser"
@@ -53,17 +54,17 @@ func (r Resource) response(resourceType ResourceType) ResourceAttributes {
 // ResourceHandler represents a set of callback method that connect the SCIM server with a provider of a certain resource.
 type ResourceHandler interface {
 	// Create stores given attributes. Returns a resource with the attributes that are stored and a (new) unique identifier.
-	Create(attributes ResourceAttributes) (Resource, errors.PostError)
+	Create(r *http.Request, attributes ResourceAttributes) (Resource, errors.PostError)
 	// Get returns the resource corresponding with the given identifier.
-	Get(id string) (Resource, errors.GetError)
+	Get(r *http.Request, id string) (Resource, errors.GetError)
 	// GetAll returns a paginated list of resources.
-	GetAll(params ListRequestParams) (Page, errors.GetError)
+	GetAll(r *http.Request, params ListRequestParams) (Page, errors.GetError)
 	// Replace replaces ALL existing attributes of the resource with given identifier. Given attributes that are empty
 	// are to be deleted. Returns a resource with the attributes that are stored.
-	Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError)
+	Replace(r *http.Request, id string, attributes ResourceAttributes) (Resource, errors.PutError)
 	// Delete removes the resource with corresponding ID.
-	Delete(id string) errors.DeleteError
+	Delete(r *http.Request, id string) errors.DeleteError
 	// Patch update one or more attributes of a SCIM resource using a sequence of
 	// operations to "add", "remove", or "replace" values.
-	Patch(id string, request PatchRequest) (Resource, errors.PatchError)
+	Patch(r *http.Request, id string, request PatchRequest) (Resource, errors.PatchError)
 }

--- a/resource_handler_test.go
+++ b/resource_handler_test.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"time"
 
 	"github.com/elimity-com/scim/errors"
@@ -20,7 +21,7 @@ type testResourceHandler struct {
 	data map[string]ResourceAttributes
 }
 
-func (h testResourceHandler) Create(attributes ResourceAttributes) (Resource, errors.PostError) {
+func (h testResourceHandler) Create(r *http.Request, attributes ResourceAttributes) (Resource, errors.PostError) {
 	// create unique identifier
 	rand.Seed(time.Now().UnixNano())
 	id := fmt.Sprintf("%04d", rand.Intn(9999))
@@ -35,7 +36,7 @@ func (h testResourceHandler) Create(attributes ResourceAttributes) (Resource, er
 	}, errors.PostErrorNil
 }
 
-func (h testResourceHandler) Get(id string) (Resource, errors.GetError) {
+func (h testResourceHandler) Get(r *http.Request, id string) (Resource, errors.GetError) {
 	// check if resource exists
 	data, ok := h.data[id]
 	if !ok {
@@ -49,7 +50,7 @@ func (h testResourceHandler) Get(id string) (Resource, errors.GetError) {
 	}, errors.GetErrorNil
 }
 
-func (h testResourceHandler) GetAll(params ListRequestParams) (Page, errors.GetError) {
+func (h testResourceHandler) GetAll(r *http.Request, params ListRequestParams) (Page, errors.GetError) {
 	resources := make([]Resource, 0)
 	i := 1
 
@@ -73,7 +74,7 @@ func (h testResourceHandler) GetAll(params ListRequestParams) (Page, errors.GetE
 	}, errors.GetErrorNil
 }
 
-func (h testResourceHandler) Replace(id string, attributes ResourceAttributes) (Resource, errors.PutError) {
+func (h testResourceHandler) Replace(r *http.Request, id string, attributes ResourceAttributes) (Resource, errors.PutError) {
 	// check if resource exists
 	_, ok := h.data[id]
 	if !ok {
@@ -90,7 +91,7 @@ func (h testResourceHandler) Replace(id string, attributes ResourceAttributes) (
 	}, errors.PutErrorNil
 }
 
-func (h testResourceHandler) Delete(id string) errors.DeleteError {
+func (h testResourceHandler) Delete(r *http.Request, id string) errors.DeleteError {
 	// check if resource exists
 	_, ok := h.data[id]
 	if !ok {
@@ -103,7 +104,7 @@ func (h testResourceHandler) Delete(id string) errors.DeleteError {
 	return errors.DeleteErrorNil
 }
 
-func (h testResourceHandler) Patch(id string, req PatchRequest) (Resource, errors.PatchError) {
+func (h testResourceHandler) Patch(r *http.Request, id string, req PatchRequest) (Resource, errors.PatchError) {
 	for _, op := range req.Operations {
 		switch op.Op {
 		case PatchOperationAdd:


### PR DESCRIPTION
* Inject `http.Request` into handlers

Closes #70. I don't love implementing another breaking change but this would be quite useful for consumers that are exposing a SCIM API to their various customers. In my case I determined I necessitate support for tenancy. 