### PR TITLE
Fix PATCH validation bug, replace can omit path

### DIFF
--- a/resource_type.go
+++ b/resource_type.go
@@ -159,7 +159,7 @@ func (t ResourceType) validateOperation(op PatchOperation) []string {
 
 	// "remove" operations require a path.
 	// The "replace" and "add" operations can have implicit paths, which is part of the value.
-	if op.Op == PatchOperationReplace && op.Path == "" {
+	if op.Op == PatchOperationRemove && op.Path == "" {
 		errorCauses = append(errorCauses, "path is required on a remove operation")
 	}
 


### PR DESCRIPTION
Noticed this issue after updating to the latest, remove is the only operation that requires a path.