### PR TITLE
Fix validation of integers and decimals.

### DIFF
--- a/schema/core.go
+++ b/schema/core.go
@@ -1,8 +1,8 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -185,15 +185,31 @@ func (a CoreAttribute) validateSingular(attribute interface{}) (interface{}, err
 		}
 		return date, errors.ValidationErrorNil
 	case attributeDataTypeDecimal:
-		if reflect.TypeOf(attribute).Kind() != reflect.Float64 {
+		switch n := attribute.(type) {
+		case json.Number:
+			f, err := n.Float64()
+			if err != nil {
+				return nil, errors.ValidationErrorInvalidValue
+			}
+			return f, errors.ValidationErrorNil
+		case float64:
+			return n, errors.ValidationErrorNil
+		default:
 			return nil, errors.ValidationErrorInvalidValue
 		}
-		return attribute.(float64), errors.ValidationErrorNil
 	case attributeDataTypeInteger:
-		if reflect.TypeOf(attribute).Kind() != reflect.Int {
+		switch n := attribute.(type) {
+		case json.Number:
+			i, err := n.Int64()
+			if err != nil {
+				return nil, errors.ValidationErrorInvalidValue
+			}
+			return i, errors.ValidationErrorNil
+		case int, int8, int16, int32, int64:
+			return n, errors.ValidationErrorNil
+		default:
 			return nil, errors.ValidationErrorInvalidValue
 		}
-		return attribute.(int), errors.ValidationErrorNil
 	case attributeDataTypeString, attributeDataTypeReference:
 		s, ok := attribute.(string)
 		if !ok {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -62,7 +62,15 @@ var testSchema = Schema{
 			Type: AttributeTypeInteger(),
 		})),
 		SimpleCoreAttribute(SimpleNumberParams(NumberParams{
+			Name: "integerNumber",
+			Type: AttributeTypeInteger(),
+		})),
+		SimpleCoreAttribute(SimpleNumberParams(NumberParams{
 			Name: "decimal",
+			Type: AttributeTypeDecimal(),
+		})),
+		SimpleCoreAttribute(SimpleNumberParams(NumberParams{
+			Name: "decimalNumber",
 			Type: AttributeTypeDecimal(),
 		})),
 	},
@@ -173,6 +181,20 @@ func TestValidationInvalid(t *testing.T) {
 			},
 			"decimal": "1.1",
 		},
+		{ // invalid type integer (json.Number)
+			"required": "present",
+			"booleans": []interface{}{
+				true,
+			},
+			"integerNumber": json.Number("1.1"),
+		},
+		{ // invalid type decimal (json.Number)
+			"required": "present",
+			"booleans": []interface{}{
+				true,
+			},
+			"decimalNumber": json.Number("fail"),
+		},
 	} {
 		if _, scimErr := testSchema.Validate(test); scimErr == errors.ValidationErrorNil {
 			t.Errorf("invalid resource expected")
@@ -192,10 +214,12 @@ func TestValidValidation(t *testing.T) {
 					"sub": "present",
 				},
 			},
-			"binary":   "ZXhhbXBsZQ==",
-			"dateTime": "2008-01-23T04:56:22Z",
-			"integer":  11,
-			"decimal":  -2.1e5,
+			"binary":        "ZXhhbXBsZQ==",
+			"dateTime":      "2008-01-23T04:56:22Z",
+			"integer":       11,
+			"decimal":       -2.1e5,
+			"integerNumber": json.Number("11"),
+			"decimalNumber": json.Number("11.12"),
 		},
 	} {
 		if _, scimErr := testSchema.Validate(test); scimErr != errors.ValidationErrorNil {


### PR DESCRIPTION
The `json.Decoder` is configured with `UseNumber()`, and because of this, all the numbers are decoded to `type json.Number string` and were failing in the validation.