### PR TITLE
Add support for a noTarget error on Patch operations.

### DIFF
--- a/error.go
+++ b/error.go
@@ -25,6 +25,8 @@ const (
 	scimTypeInvalidValue = "invalidValue"
 	// Endpoint not implemented
 	scimTypeNotImplemented = "notImplemented"
+	// When a path does not return a valid target.
+	scimTypeNoTarget = "noTarget"
 )
 
 func scimErrorResourceNotFound(id string) scimError {
@@ -82,6 +84,11 @@ var (
 	scimErrorNotImplemented = scimError{
 		scimType: scimTypeNotImplemented,
 		status:   http.StatusNotImplemented,
+	}
+	scimErrorNoTarget = scimError{
+		scimType: scimTypeNoTarget,
+		detail:   "The specified path did not yield an attribute or attribute value that could be operated on.",
+		status:   http.StatusBadRequest,
 	}
 )
 
@@ -164,6 +171,8 @@ func scimPatchError(patchError errors.PatchError, id string) scimError {
 		return scimErrorMutability
 	case errors.PatchErrorResourceNotFound:
 		return scimErrorResourceNotFound(id)
+	case errors.PatchErrorNoTarget:
+		return scimErrorNoTarget
 	default:
 		return scimErrorInternalServer
 	}

--- a/errors/error.go
+++ b/errors/error.go
@@ -27,7 +27,7 @@ const (
 	// PatchErrorResourceNotFound returns an error with status code 404 and a human readable message containing the
 	// identifier of the resource that was requested to be replaced but not found.
 	PatchErrorResourceNotFound
-	// PatchErrorNotTarget shall be returned when a specified "path" does not
+	// PatchErrorNoTarget shall be returned when a specified "path" does not
 	// yield an attribute or attribute value that can be operated on. This
 	// occurs when the specified "path" value contains a filter that yields no
 	// match.

--- a/errors/error.go
+++ b/errors/error.go
@@ -27,6 +27,11 @@ const (
 	// PatchErrorResourceNotFound returns an error with status code 404 and a human readable message containing the
 	// identifier of the resource that was requested to be replaced but not found.
 	PatchErrorResourceNotFound
+	// PatchErrorNotTarget shall be returned when a specified "path" does not
+	// yield an attribute or attribute value that can be operated on. This
+	// occurs when the specified "path" value contains a filter that yields no
+	// match.
+	PatchErrorNoTarget
 	// PatchErrorNotImplemented allows consumers to create a patch handler that simply returns an unsupported error.
 	PatchErrorNotImplemented
 )


### PR DESCRIPTION
### Description
This PR adds support for the `noTarget` error on Patch operation.

RFC7644 sections [3.5.2.2](https://tools.ietf.org/html/rfc7644#section-3.5.2.2) and [3.5.2.3](https://tools.ietf.org/html/rfc7644#section-3.5.2.3) specify cases when a `noTarget`
error must be returned.