### PR TITLE
Return empty resources instead of null

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -244,7 +244,7 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 		return
 	}
 
-	var resources []interface{}
+	resources := []interface{}{}
 	for _, v := range page.Resources {
 		resources = append(resources, v.response(resourceType))
 	}


### PR DESCRIPTION
### Description

Despite that the SCIM spec allows both null an [], some IdPs do
not manage properly null in all the cases. Returning an empty
array if GetAll does not return any resource is more compatible.