### PR TITLE
Match patch operations in a case-insensitive way

### DIFF
--- a/resource_type.go
+++ b/resource_type.go
@@ -122,8 +122,9 @@ func (t ResourceType) validatePatch(r *http.Request) (PatchRequest, errors.Valid
 		return req, errors.ValidationErrorInvalidValue
 	}
 
-	for _, op := range req.Operations {
-		errorCauses = append(errorCauses, t.validateOperation(op)...)
+	for i := range req.Operations {
+		req.Operations[i].Op = strings.ToLower(req.Operations[i].Op)
+		errorCauses = append(errorCauses, t.validateOperation(req.Operations[i])...)
 	}
 
 	// Denotes all of the errors that have occurred parsing the request.


### PR DESCRIPTION
### Description
This PR makes sure the operations are lower case, I've found that an app using SCIM through Azure Active Directory, receives add operations like:

```json
{
    "schemas": [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ],
    "Operations": [
        {
            "op": "Add",
            "path": "members",
            "value": [
                {
                    "value": "4143f2ee-d771-46d6-9a0a-74a9f7296ea7"
                }
            ]
        }
    ]
}
```