### PR TITLE
Fix patch validation logic when `path.SubAttribute` has a value

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -810,6 +810,28 @@ func TestServerResourcePatchHandlerInvalidPath(t *testing.T) {
 	assertEqualSCIMErrors(t, &errors.ScimErrorInvalidPath, scimErr)
 }
 
+func TestServerResourcePatchHandlerValidPathHasSubAttributes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+		"Operations":[
+		  {
+		    "op":"replace",
+		    "path":"name.givenName",
+		    "value":"test"
+		  },
+		  {
+		    "op":"replace",
+		    "path":"name.familyName",
+		    "value":"test"
+		  }
+		]
+	}`))
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, req)
+
+	assertEqualStatusCode(t, http.StatusOK, rr.Code)
+}
+
 func TestServerResourcePutHandlerValid(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/resource_type.go
+++ b/resource_type.go
@@ -215,7 +215,7 @@ func (t ResourceType) validateOperationValue(op PatchOperation) *errors.ScimErro
 		}
 	}
 
-	mapValue := make(map[string]interface{})
+	var mapValue map[string]interface{}
 	switch v := op.Value.(type) {
 	case map[string]interface{}:
 		mapValue = v

--- a/resource_type.go
+++ b/resource_type.go
@@ -215,9 +215,19 @@ func (t ResourceType) validateOperationValue(op PatchOperation) *errors.ScimErro
 		}
 	}
 
-	mapValue, ok := op.Value.(map[string]interface{})
-	if !ok {
-		mapValue = map[string]interface{}{path.AttributeName: op.Value}
+	mapValue := make(map[string]interface{})
+	switch v := op.Value.(type) {
+	case map[string]interface{}:
+		mapValue = v
+
+	default:
+		if path.SubAttribute == "" {
+			mapValue = map[string]interface{}{path.AttributeName: v}
+			break
+		}
+		mapValue = map[string]interface{}{path.AttributeName: map[string]interface{}{
+			path.SubAttribute: v,
+		}}
 	}
 
 	// Check if it's a patch on an extension.


### PR DESCRIPTION
I found what appeared to be a bug while validating a PATCH request using this nice library.

Using the following JSON in my request will result in an error.
This error was from [here](https://github.com/elimity-com/scim/blob/fd9c1e6e7be41b15dfddb4ba14eafc94204f8630/schema/core.go#L232-L235).

```json
{
  "schema": [
    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
  ],
  "Operations": [
    {
      "op": "replace",
      "path": "name.givenName",
      "value": "test"
    }
  ]
}

```

The reason why this error happens is it does not handle the case if `path.SubAttribute` has a value, I guess.

https://github.com/elimity-com/scim/blob/fd9c1e6e7be41b15dfddb4ba14eafc94204f8630/resource_type.go#L218-L221

After modifying the codes, validation of the above request was successful.

Please review this pull request🙇‍♂️ @di-wu 