### PR TITLE
Handle patch response nil case

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -1,7 +1,6 @@
 package scim
 
 import (
-	"context"
 	"log"
 	"net/http"
 )
@@ -19,17 +18,4 @@ func ExampleNewServer_basePath() {
 		ResourceTypes: nil,
 	}))
 	log.Fatal(http.ListenAndServe(":7643", nil))
-}
-
-type contextKey struct{ name string }
-
-var requestNoChange = contextKey{"RequestNoChange"}
-
-func tellRequestNoChange(r *http.Request) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), requestNoChange, struct{}{}))
-}
-
-func isRequestNoChange(r *http.Request) bool {
-	_, ok := r.Context().Value(requestNoChange).(struct{})
-	return ok
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,7 @@
 package scim
 
 import (
+	"context"
 	"log"
 	"net/http"
 )
@@ -18,4 +19,17 @@ func ExampleNewServer_basePath() {
 		ResourceTypes: nil,
 	}))
 	log.Fatal(http.ListenAndServe(":7643", nil))
+}
+
+type contextKey struct{ name string }
+
+var requestNoChange = contextKey{"RequestNoChange"}
+
+func tellRequestNoChange(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), requestNoChange, struct{}{}))
+}
+
+func isRequestNoChange(r *http.Request) bool {
+	_, ok := r.Context().Value(requestNoChange).(struct{})
+	return ok
 }

--- a/handlers.go
+++ b/handlers.go
@@ -190,7 +190,7 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	if resource.Attributes == nil {
+	if len(resource.Attributes) == 0 {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -190,6 +190,11 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
+	if resource.Attributes == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	raw, err := json.Marshal(resource.response(resourceType))
 	if err != nil {
 		errorHandler(w, r, &errors.ScimErrorInternal)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -923,23 +923,33 @@ func TestServerResourceDeleteHandlerNotFound(t *testing.T) {
 	assertEqualSCIMErrors(t, expectedError, scimErr)
 }
 
-func TestServerResourcePatchGroupsHandlerNoContent(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPatch, "/Groups/0001", strings.NewReader(`{
-		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-		"Operations":[
-		  {
-		    "op": "add",
-		    "path": "members",
-		    "value": [
-				{
-					"value": "0001"
-				}
+func TestServerResourcePatchHandlerReturnsNoContent(t *testing.T) {
+	reqs := []*http.Request{
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op": "add",
+				"path": "userName",
+				"value": "test01"
+			  }
 			]
-		  }
-		]
-	}`))
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, tellRequestNoChange(req))
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0002", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op": "replace",
+				"path": "userName",
+				"value": "test02"
+			  }
+			]
+		}`)),
+	}
+	for _, req := range reqs {
+		rr := httptest.NewRecorder()
+		newTestServer().ServeHTTP(rr, req)
 
-	assertEqualStatusCode(t, http.StatusNoContent, rr.Code)
+		assertEqualStatusCode(t, http.StatusNoContent, rr.Code)
+	}
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -922,3 +922,24 @@ func TestServerResourceDeleteHandlerNotFound(t *testing.T) {
 	}
 	assertEqualSCIMErrors(t, expectedError, scimErr)
 }
+
+func TestServerResourcePatchGroupsHandlerNoContent(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPatch, "/Groups/0001", strings.NewReader(`{
+		"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+		"Operations":[
+		  {
+		    "op": "add",
+		    "path": "members",
+		    "value": [
+				{
+					"value": "0001"
+				}
+			]
+		  }
+		]
+	}`))
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, tellRequestNoChange(req))
+
+	assertEqualStatusCode(t, http.StatusNoContent, rr.Code)
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -693,7 +693,7 @@ func TestServerResourcePatchHandlerValidRemoveOp(t *testing.T) {
 	rr := httptest.NewRecorder()
 	newTestServer().ServeHTTP(rr, req)
 
-	assertEqualStatusCode(t, http.StatusOK, rr.Code)
+	assertEqualStatusCode(t, http.StatusNoContent, rr.Code)
 }
 
 func TestServerResourcePatchHandlerInvalidRemoveOp(t *testing.T) {
@@ -942,6 +942,15 @@ func TestServerResourcePatchHandlerReturnsNoContent(t *testing.T) {
 				"op": "replace",
 				"path": "userName",
 				"value": "test02"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0003", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op": "remove",
+				"path": "name.givenName"
 			  }
 			]
 		}`)),

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -101,6 +101,10 @@ type ResourceHandler interface {
 	Delete(r *http.Request, id string) error
 	// Patch update one or more attributes of a SCIM resource using a sequence of
 	// operations to "add", "remove", or "replace" values.
-	// If you return empty Resource.Attributes, 204 No Content will be response.
+	// If you return no Resource.Attributes, a 204 No Content status code will be returned.
+	// This case is only valid in the following scenarios:
+	// 1. the Add/Replace operation should return No Content only when the value already exists AND is the same.
+	// 2. the Remove operation should return No Content when the value to be remove is already absent.
+	// More information in Section 3.5.2 of RFC 7644: https://tools.ietf.org/html/rfc7644#section-3.5.2
 	Patch(r *http.Request, id string, request PatchRequest) (Resource, error)
 }

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -101,5 +101,6 @@ type ResourceHandler interface {
 	Delete(r *http.Request, id string) error
 	// Patch update one or more attributes of a SCIM resource using a sequence of
 	// operations to "add", "remove", or "replace" values.
+	// If you return empty Resource.Attributes, 204 No Content will be response.
 	Patch(r *http.Request, id string, request PatchRequest) (Resource, error)
 }

--- a/resource_handler_test.go
+++ b/resource_handler_test.go
@@ -134,6 +134,9 @@ func (h testResourceHandler) Delete(r *http.Request, id string) error {
 }
 
 func (h testResourceHandler) Patch(r *http.Request, id string, req PatchRequest) (Resource, error) {
+	if isRequestNoChange(r) {
+		return Resource{}, nil
+	}
 	for _, op := range req.Operations {
 		switch op.Op {
 		case PatchOperationAdd:


### PR DESCRIPTION
I am trying to integrate with AzureAD using this wonderful library.
And I want to support [this case](https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#update-group-add-members)(AzureAD wants `204 No Content` after `PATCH /Groups` request).

Could you review this pull request? 🙇 