### PR TITLE
Accepts string type boolean

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -832,6 +832,77 @@ func TestServerResourcePatchHandlerValidPathHasSubAttributes(t *testing.T) {
 	assertEqualStatusCode(t, http.StatusOK, rr.Code)
 }
 
+func TestServerResourcePatchHandlerAcceptsStringBoolean(t *testing.T) {
+	reqs := []*http.Request{
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"False"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"false"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"FALSE"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"True"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"true"
+			  }
+			]
+		}`)),
+		httptest.NewRequest(http.MethodPatch, "/Users/0001", strings.NewReader(`{
+			"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+			"Operations":[
+			  {
+				"op":"replace",
+				"path":"active",
+				"value":"TRUE"
+			  }
+			]
+		}`)),
+	}
+	for _, req := range reqs {
+		rr := httptest.NewRecorder()
+		newTestServer().ServeHTTP(rr, req)
+
+		assertEqualStatusCode(t, http.StatusOK, rr.Code)
+	}
+}
+
 func TestServerResourcePutHandlerValid(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/schema/core.go
+++ b/schema/core.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	datetime "github.com/di-wu/xsd-datetime"
@@ -222,12 +223,18 @@ func (a CoreAttribute) validateSingular(attribute interface{}) (interface{}, *er
 
 		return bin, nil
 	case attributeDataTypeBoolean:
-		b, ok := attribute.(bool)
-		if !ok {
+		switch b := attribute.(type) {
+		case string:
+			boolean, err := strconv.ParseBool(b)
+			if err != nil {
+				return nil, &errors.ScimErrorInvalidValue
+			}
+			return boolean, nil
+		case bool:
+			return b, nil
+		default:
 			return nil, &errors.ScimErrorInvalidValue
 		}
-
-		return b, nil
 	case attributeDataTypeComplex:
 		complex, ok := attribute.(map[string]interface{})
 		if !ok {


### PR DESCRIPTION
Hi there.

I want to pass string type boolean through `validateSingular()`.

https://github.com/elimity-com/scim/blob/1bc6b4a9715467679091130ef48e1051ea1f9c21/schema/core.go#L206

The reason why I want to modify is AzureAD request below.

```json
{
        "schemas": [
                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
        ],
        "Operations": [
                {
                        "op": "Replace",
                        "path": "active",
                        "value": "False" # string type
                }
        ]
}
```