### PR TITLE
Fix immutable attribute validation.

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -468,6 +468,12 @@ func TestServerResourcePostHandlerValid(t *testing.T) {
 			body:               strings.NewReader(`{"id": "other", "userName": "test3"}`),
 			expectedUserName:   "test3",
 			expectedExternalID: nil,
+		},{
+			name:               "Users post request with immutable attribute",
+			target:             "/v2/Users",
+			body:               strings.NewReader(`{"id": "other", "userName": "test3", "immutableThing": "test"}`),
+			expectedUserName:   "test3",
+			expectedExternalID: nil,
 		},
 	}
 
@@ -850,6 +856,12 @@ func TestServerResourcePutHandlerValid(t *testing.T) {
 			name:               "Users put request without externalId",
 			target:             "/Users/0003",
 			body:               strings.NewReader(`{"id": "other", "userName": "test3"}`),
+			expectedUserName:   "test3",
+			expectedExternalID: nil,
+		}, {
+			name:               "Users put request with immutable attribute",
+			target:             "/Users/0003",
+			body:               strings.NewReader(`{"id": "other", "userName": "test3", "immutableThing": "test"}`),
 			expectedUserName:   "test3",
 			expectedExternalID: nil,
 		},

--- a/resource_type.go
+++ b/resource_type.go
@@ -60,7 +60,7 @@ func (t ResourceType) validate(raw []byte, method string) (ResourceAttributes, *
 	var attributes map[string]interface{}
 	var scimErr *errors.ScimError
 	switch method {
-	case http.MethodGet, http.MethodPut:
+	case http.MethodPost, http.MethodPut:
 		attributes, scimErr = t.schemaWithCommon().Validate(m)
 	default:
 		attributes, scimErr = t.schemaWithCommon().ValidateMutability(m)

--- a/resource_type.go
+++ b/resource_type.go
@@ -57,14 +57,7 @@ func (t ResourceType) validate(raw []byte, method string) (ResourceAttributes, *
 		return ResourceAttributes{}, &errors.ScimErrorInvalidSyntax
 	}
 
-	var attributes map[string]interface{}
-	var scimErr *errors.ScimError
-	switch method {
-	case http.MethodPost, http.MethodPut:
-		attributes, scimErr = t.schemaWithCommon().Validate(m)
-	default:
-		attributes, scimErr = t.schemaWithCommon().ValidateMutability(m)
-	}
+	attributes, scimErr := t.schemaWithCommon().Validate(m)
 	if scimErr != nil {
 		return ResourceAttributes{}, scimErr
 	}


### PR DESCRIPTION
Closes #108 

> **immutable** The attribute MAY be defined at resource creation (e.g., POST) or at record replacement via a request (e.g., a PUT).  The attribute SHALL NOT be updated.
[RFC 7643, Section 7](https://tools.ietf.org/html/rfc7643#section-7)

https://github.com/elimity-com/scim/blob/acfc5ea615ab446d3665677b1568de0f02aee359/schema/schema.go#L40-L44

Thank you @brumer for reporting this.