### PR TITLE
Skip a validation for id

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -90,6 +90,10 @@ func (s Schema) ValidatePatchOperation(operation string, operationValue map[stri
 		var attr *CoreAttribute
 		var scimErr *errors.ScimError
 
+		if k == CommonAttributeID {
+			continue
+		}
+
 		for _, attribute := range s.Attributes {
 			if strings.EqualFold(attribute.name, k) {
 				attr = &attribute


### PR DESCRIPTION
Hi, @di-wu 

I've been trying to integrate Okta with API which uses this awesome library.
This request from Okta is not valid.

```json
{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "replace",
        "value": {
            "id": "abf4dd94-a4c0-4f67-89c9-76b03340cb9b",
            "displayName": "Test SCIMv2"
        }
    }]
}
```
https://developer.okta.com/docs/reference/scim/scim-20/#update-a-specific-group-name

I would like to suggest skipping validation for `id`.

Do you have any ideas?
I appreciate your supports😊