### PR TITLE
Fix logic error causing panic in validatePatch

### DIFF
--- a/resource_type.go
+++ b/resource_type.go
@@ -134,7 +134,7 @@ func (t ResourceType) validatePatch(r *http.Request) ([]PatchOperation, *errors.
 
 	// The body of each request MUST contain the "schemas" attribute with the URI value of
 	// "urn:ietf:params:scim:api:messages:2.0:PatchOp".
-	if len(req.Schemas) != 1 && req.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
+	if len(req.Schemas) < 1 || req.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
 		return nil, &errors.ScimErrorInvalidValue
 	}
 

--- a/resource_type.go
+++ b/resource_type.go
@@ -134,7 +134,7 @@ func (t ResourceType) validatePatch(r *http.Request) ([]PatchOperation, *errors.
 
 	// The body of each request MUST contain the "schemas" attribute with the URI value of
 	// "urn:ietf:params:scim:api:messages:2.0:PatchOp".
-	if len(req.Schemas) < 1 || req.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
+	if len(req.Schemas) != 1 || req.Schemas[0] != "urn:ietf:params:scim:api:messages:2.0:PatchOp" {
 		return nil, &errors.ScimErrorInvalidValue
 	}
 


### PR DESCRIPTION
Line 137:
Check for != 1 was matching when len() == 0 and
falling through to evaluate second term of &&
causing an array out of bounds panic.

This changes check for len() < 1 and short circuits
using || operator instead.