### PR TITLE
Add Okta On-Prem connector compatibility changes

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -5,7 +5,7 @@ package scim
 // "default". This attribute SHALL be ignored when provided by clients.
 type meta struct {
 	// ResourceType is the name of the resource type of the resource.
-	ResourceType string `json:"resourceType"`
+	ResourceType string `json:"resourceType,omitempty"`
 	// Created is the "DateTime" that the resource was added to the service provider.
 	Created string `json:"created,omitempty"`
 	// LastModified is the most recent DateTime that the details of this resource were updated at the service provider.

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -65,8 +65,11 @@ func (r Resource) response(resourceType ResourceType) ResourceAttributes {
 	response["schemas"] = schemas
 
 	m := meta{
-		ResourceType: resourceType.Name,
-		Location:     fmt.Sprintf("%s/%s", resourceType.Endpoint[1:], url.PathEscape(r.ID)),
+		Location: fmt.Sprintf("%s/%s", resourceType.Endpoint[1:], url.PathEscape(r.ID)),
+	}
+
+	if !resourceType.ExcludeResourceTypeMeta {
+		m.ResourceType = resourceType.Name
 	}
 
 	if r.Meta.Created != nil {

--- a/resource_type.go
+++ b/resource_type.go
@@ -36,6 +36,9 @@ type ResourceType struct {
 
 	// Handler is the set of callback method that connect the SCIM server with a provider of the resource type.
 	Handler ResourceHandler
+
+	// ExcludeResourceTypeMeta controls whether the meta block will contain the resource_type key
+	ExcludeResourceTypeMeta bool
 }
 
 func (t ResourceType) getRaw() map[string]interface{} {

--- a/server.go
+++ b/server.go
@@ -2,12 +2,13 @@ package scim
 
 import (
 	"fmt"
-	f "github.com/elimity-com/scim/internal/filter"
-	"github.com/scim2/filter-parser/v2"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	f "github.com/elimity-com/scim/internal/filter"
+	"github.com/scim2/filter-parser/v2"
 
 	"github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/schema"
@@ -88,7 +89,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(path, "/ResourceTypes/") && r.Method == http.MethodGet:
 		s.resourceTypeHandler(w, r, strings.TrimPrefix(path, "/ResourceTypes/"))
 		return
-	case path == "/ServiceProviderConfig":
+	case path == "/ServiceProviderConfig" || path == "/ServiceProviderConfigs":
 		s.serviceProviderConfigHandler(w, r)
 		return
 	}


### PR DESCRIPTION
Add ServiceCapabilities field to ServiceProviderConfig struct
to allow customization of SCIM service capabilities.
Backwards compatibility is maintained by using the previous
list of capabilities if this list is empty.

Add SchemaExtensions field to ServiceProviderConfig struct
to allow augmenting the list of schemas returned by the
/ServiceProviderConfig end-point.

Add ExcludeResourceTypeMeta field to ResourceType struct
to allow for excluding the resource_type field in the response
meta object. This field breaks the Okta on-prem connector agent.
This field was named such to maintain backwards compatibility with
existing code that would not specify this.

Resource.response was changed to consult this new ResourceType field.

Add omitempty flag to meta.ResourceType's json tag