### PR TITLE
Remove double unescape

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -92,7 +92,7 @@ func Test_User_Filter(t *testing.T) {
 
 			userName, ok := firstResource["userName"].(string)
 			if !ok {
-				t.Fatal("userName is not a string")
+				t.Fatal("userName is not the right type or missing")
 			}
 
 			if userName != tt.expectedUserName {
@@ -110,8 +110,8 @@ func Test_Group_Filter(t *testing.T) {
 		filter              string
 		expectedDisplayName string
 	}{
-		{name: "Happy path", filter: "displayName eq \"testUser\"", expectedDisplayName: "testGroup"},
-		{name: "Happy path with plus sign", filter: "displayName eq \"testUser+test\"", expectedDisplayName: "testGroup+test"},
+		{name: "Happy path", filter: "displayName eq \"testGroup\"", expectedDisplayName: "testGroup"},
+		{name: "Happy path with plus sign", filter: "displayName eq \"testGroup+test\"", expectedDisplayName: "testGroup+test"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -144,9 +144,9 @@ func Test_Group_Filter(t *testing.T) {
 				t.Fatal("first Resource is not the right type or missing")
 			}
 
-			userName, ok := firstResource["userName"].(string)
+			userName, ok := firstResource["displayName"].(string)
 			if !ok {
-				t.Fatal("displayName is not a string")
+				t.Fatal("displayName is not the right type or missing")
 			}
 
 			if userName != tt.expectedDisplayName {

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,101 @@
+package scim_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/elimity-com/scim"
+	"github.com/elimity-com/scim/optional"
+	"github.com/elimity-com/scim/schema"
+)
+
+func newTestServerForFilter() scim.Server {
+	return scim.Server{
+		ResourceTypes: []scim.ResourceType{
+			{
+				ID:          optional.NewString("User"),
+				Name:        "User",
+				Endpoint:    "/Users",
+				Description: optional.NewString("User Account"),
+				Schema:      schema.CoreUserSchema(),
+				Handler: &testResourceHandler{
+					data: map[string]testData{
+						"0001": {attributes: map[string]interface{}{"userName": "testUser"}},
+						"0002": {attributes: map[string]interface{}{"userName": "testUser+test"}},
+					},
+					schema: schema.CoreUserSchema(),
+				},
+			},
+			{
+				ID:          optional.NewString("Group"),
+				Name:        "Group",
+				Endpoint:    "/Groups",
+				Description: optional.NewString("Group"),
+				Schema:      schema.CoreGroupSchema(),
+				Handler: &testResourceHandler{
+					data: map[string]testData{
+						"0001": {attributes: map[string]interface{}{"displayName": "testGroup"}},
+						"0002": {attributes: map[string]interface{}{"displayName": "testGroup+test"}},
+					},
+					schema: schema.CoreGroupSchema(),
+				},
+			},
+		},
+	}
+}
+
+func Test_User_Filter(t *testing.T) {
+
+	s := newTestServerForFilter()
+
+	tests := []struct {
+		name             string
+		filter           string
+		expectedUserName string
+	}{
+		{name: "Happy path", filter: "userName eq \"testUser\"", expectedUserName: "testUser"},
+		{name: "Happy path with plus sign", filter: "userName eq \"testUser+test\"", expectedUserName: "testUser+test"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/Users?filter="+url.QueryEscape(tt.filter), nil)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, r)
+
+			bytes, err := ioutil.ReadAll(w.Result().Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if w.Result().StatusCode != http.StatusOK {
+				t.Fatal(w.Result().StatusCode, string(bytes))
+			}
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(bytes, &result); err != nil {
+				t.Fatal(err)
+			}
+
+			resources, ok := result["Resources"].([]interface{})
+			if !ok {
+				t.Fatal("Resources not found")
+			}
+
+			firstResource, ok := resources[0].(map[string]interface{})
+
+			userName, ok := firstResource["userName"].(string)
+			if !ok {
+				t.Fatal("userName is not a string")
+			}
+
+			if userName != tt.expectedUserName {
+				t.Fatal("userName not eq " + userName)
+			}
+		})
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -50,6 +50,10 @@ func Test_Group_Filter(t *testing.T) {
 				t.Fatal("Resources is not the right type or missing")
 			}
 
+			if len(resources) != 1 {
+				t.Fatal("one Resource expected")
+			}
+
 			firstResource, ok := resources[0].(map[string]interface{})
 			if !ok {
 				t.Fatal("first Resource is not the right type or missing")
@@ -102,6 +106,10 @@ func Test_User_Filter(t *testing.T) {
 			resources, ok := result["Resources"].([]interface{})
 			if !ok {
 				t.Fatal("Resources is not the right type or missing")
+			}
+
+			if len(resources) != 1 {
+				t.Fatal("one Resource expected")
 			}
 
 			firstResource, ok := resources[0].(map[string]interface{})

--- a/filter_test.go
+++ b/filter_test.go
@@ -144,13 +144,13 @@ func Test_Group_Filter(t *testing.T) {
 				t.Fatal("first Resource is not the right type or missing")
 			}
 
-			userName, ok := firstResource["displayName"].(string)
+			displayName, ok := firstResource["displayName"].(string)
 			if !ok {
 				t.Fatal("displayName is not the right type or missing")
 			}
 
-			if userName != tt.expectedDisplayName {
-				t.Fatal("displayName not eq " + userName)
+			if displayName != tt.expectedDisplayName {
+				t.Fatal("displayName not eq " + displayName)
 			}
 		})
 	}

--- a/filter_test.go
+++ b/filter_test.go
@@ -13,38 +13,57 @@ import (
 	"github.com/elimity-com/scim/schema"
 )
 
-func newTestServerForFilter() scim.Server {
-	return scim.Server{
-		ResourceTypes: []scim.ResourceType{
-			{
-				ID:          optional.NewString("User"),
-				Name:        "User",
-				Endpoint:    "/Users",
-				Description: optional.NewString("User Account"),
-				Schema:      schema.CoreUserSchema(),
-				Handler: &testResourceHandler{
-					data: map[string]testData{
-						"0001": {attributes: map[string]interface{}{"userName": "testUser"}},
-						"0002": {attributes: map[string]interface{}{"userName": "testUser+test"}},
-					},
-					schema: schema.CoreUserSchema(),
-				},
-			},
-			{
-				ID:          optional.NewString("Group"),
-				Name:        "Group",
-				Endpoint:    "/Groups",
-				Description: optional.NewString("Group"),
-				Schema:      schema.CoreGroupSchema(),
-				Handler: &testResourceHandler{
-					data: map[string]testData{
-						"0001": {attributes: map[string]interface{}{"displayName": "testGroup"}},
-						"0002": {attributes: map[string]interface{}{"displayName": "testGroup+test"}},
-					},
-					schema: schema.CoreGroupSchema(),
-				},
-			},
-		},
+func Test_Group_Filter(t *testing.T) {
+	s := newTestServerForFilter()
+
+	tests := []struct {
+		name                string
+		filter              string
+		expectedDisplayName string
+	}{
+		{name: "Happy path", filter: "displayName eq \"testGroup\"", expectedDisplayName: "testGroup"},
+		{name: "Happy path with plus sign", filter: "displayName eq \"testGroup+test\"", expectedDisplayName: "testGroup+test"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/Groups?filter="+url.QueryEscape(tt.filter), nil)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, r)
+
+			bytes, err := ioutil.ReadAll(w.Result().Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if w.Result().StatusCode != http.StatusOK {
+				t.Fatal(w.Result().StatusCode, string(bytes))
+			}
+
+			var result map[string]interface{}
+			if err := json.Unmarshal(bytes, &result); err != nil {
+				t.Fatal(err)
+			}
+
+			resources, ok := result["Resources"].([]interface{})
+			if !ok {
+				t.Fatal("Resources is not the right type or missing")
+			}
+
+			firstResource, ok := resources[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("first Resource is not the right type or missing")
+			}
+
+			displayName, ok := firstResource["displayName"].(string)
+			if !ok {
+				t.Fatal("displayName is not the right type or missing")
+			}
+
+			if displayName != tt.expectedDisplayName {
+				t.Fatal("displayName not eq " + displayName)
+			}
+		})
 	}
 }
 
@@ -102,56 +121,37 @@ func Test_User_Filter(t *testing.T) {
 	}
 }
 
-func Test_Group_Filter(t *testing.T) {
-	s := newTestServerForFilter()
-
-	tests := []struct {
-		name                string
-		filter              string
-		expectedDisplayName string
-	}{
-		{name: "Happy path", filter: "displayName eq \"testGroup\"", expectedDisplayName: "testGroup"},
-		{name: "Happy path with plus sign", filter: "displayName eq \"testGroup+test\"", expectedDisplayName: "testGroup+test"},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodGet, "/Groups?filter="+url.QueryEscape(tt.filter), nil)
-			w := httptest.NewRecorder()
-			s.ServeHTTP(w, r)
-
-			bytes, err := ioutil.ReadAll(w.Result().Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if w.Result().StatusCode != http.StatusOK {
-				t.Fatal(w.Result().StatusCode, string(bytes))
-			}
-
-			var result map[string]interface{}
-			if err := json.Unmarshal(bytes, &result); err != nil {
-				t.Fatal(err)
-			}
-
-			resources, ok := result["Resources"].([]interface{})
-			if !ok {
-				t.Fatal("Resources is not the right type or missing")
-			}
-
-			firstResource, ok := resources[0].(map[string]interface{})
-			if !ok {
-				t.Fatal("first Resource is not the right type or missing")
-			}
-
-			displayName, ok := firstResource["displayName"].(string)
-			if !ok {
-				t.Fatal("displayName is not the right type or missing")
-			}
-
-			if displayName != tt.expectedDisplayName {
-				t.Fatal("displayName not eq " + displayName)
-			}
-		})
+func newTestServerForFilter() scim.Server {
+	return scim.Server{
+		ResourceTypes: []scim.ResourceType{
+			{
+				ID:          optional.NewString("User"),
+				Name:        "User",
+				Endpoint:    "/Users",
+				Description: optional.NewString("User Account"),
+				Schema:      schema.CoreUserSchema(),
+				Handler: &testResourceHandler{
+					data: map[string]testData{
+						"0001": {attributes: map[string]interface{}{"userName": "testUser"}},
+						"0002": {attributes: map[string]interface{}{"userName": "testUser+test"}},
+					},
+					schema: schema.CoreUserSchema(),
+				},
+			},
+			{
+				ID:          optional.NewString("Group"),
+				Name:        "Group",
+				Endpoint:    "/Groups",
+				Description: optional.NewString("Group"),
+				Schema:      schema.CoreGroupSchema(),
+				Handler: &testResourceHandler{
+					data: map[string]testData{
+						"0001": {attributes: map[string]interface{}{"displayName": "testGroup"}},
+						"0002": {attributes: map[string]interface{}{"displayName": "testGroup+test"}},
+					},
+					schema: schema.CoreGroupSchema(),
+				},
+			},
+		},
 	}
 }

--- a/server.go
+++ b/server.go
@@ -20,16 +20,12 @@ const (
 
 // getFilter returns a validated filter if present in the url query, nil otherwise.
 func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (filter.Expression, error) {
-	rawFilter := strings.TrimSpace(r.URL.Query().Get("filter"))
-	if rawFilter == "" {
+	filter := strings.TrimSpace(r.URL.Query().Get("filter"))
+	if filter == "" {
 		return nil, nil // No filter present.
 	}
 
-	decodedFilter, err := url.QueryUnescape(rawFilter)
-	if err != nil {
-		return nil, err
-	}
-	validator, err := f.NewValidator(decodedFilter, s, extensions...)
+	validator, err := f.NewValidator(filter, s, extensions...)
 	if err != nil {
 		return nil, err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -117,10 +117,6 @@ func (h *testResourceHandler) Create(r *http.Request, attributes scim.ResourceAt
 }
 
 func (h *testResourceHandler) Delete(r *http.Request, id string) error {
-	if err := checkBodyNotEmpty(r); err != nil {
-		return err
-	}
-
 	if _, ok := h.data[id]; !ok {
 		return errors.ScimErrorResourceNotFound(id)
 	}
@@ -129,10 +125,6 @@ func (h *testResourceHandler) Delete(r *http.Request, id string) error {
 }
 
 func (h testResourceHandler) Get(r *http.Request, id string) (scim.Resource, error) {
-	if err := checkBodyNotEmpty(r); err != nil {
-		return scim.Resource{}, err
-	}
-
 	resource, ok := h.data[id]
 	if !ok {
 		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
@@ -146,10 +138,6 @@ func (h testResourceHandler) Get(r *http.Request, id string) (scim.Resource, err
 }
 
 func (h testResourceHandler) GetAll(r *http.Request, params scim.ListRequestParams) (scim.Page, error) {
-	if err := checkBodyNotEmpty(r); err != nil {
-		return scim.Page{}, err
-	}
-
 	if params.Count == 0 {
 		return scim.Page{
 			TotalResults: len(h.data),


### PR DESCRIPTION
The call to `r.URL.Query().Get("filter")` already triggers an unescape so doing it again yields incorrect values. Resolves https://github.com/elimity-com/scim/issues/133