### PR TITLE
Add schemas attribute to Schema type

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -61,6 +61,7 @@ func (s Schema) ToMap() map[string]interface{} {
 		"name":        s.Name.Value(),
 		"description": s.Description.Value(),
 		"attributes":  s.getRawAttributes(),
+		"schemas":     []string{"urn:ietf:params:scim:schemas:core:2.0:Schema"},
 	}
 }
 

--- a/schema/testdata/enterprise_user_schema.json
+++ b/schema/testdata/enterprise_user_schema.json
@@ -103,6 +103,7 @@
       "type": "complex"
     }
   ],
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
   "description": "Enterprise User",
   "id": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
   "name": "Enterprise User"

--- a/schema/testdata/group_schema.json
+++ b/schema/testdata/group_schema.json
@@ -75,6 +75,7 @@
       "type": "complex"
     }
   ],
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
   "description": "Group",
   "id": "urn:ietf:params:scim:schemas:core:2.0:Group",
   "name": "Group"

--- a/schema/testdata/schema_test.json
+++ b/schema/testdata/schema_test.json
@@ -120,6 +120,7 @@
       "uniqueness": "none"
     }
   ],
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
   "description": "",
   "id": "empty",
   "name": "test"

--- a/schema/testdata/user_schema.json
+++ b/schema/testdata/user_schema.json
@@ -757,6 +757,7 @@
       "type": "complex"
     }
   ],
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
   "description": "User Account",
   "id": "urn:ietf:params:scim:schemas:core:2.0:User",
   "name": "User"


### PR DESCRIPTION
Hi,
I'm new to SCIM, and I'm trying to build a Service Provider compatible with https://github.com/suvera/keycloak-scim2-storage.
I encountered an error, the Schema type has no `schemas` attribute wich I think is mandatory because of this section : https://datatracker.ietf.org/doc/html/rfc7643#section-3.