### PR TITLE
Add a name to Schema definition

### DIFF
--- a/schema/schemas.go
+++ b/schema/schemas.go
@@ -570,7 +570,7 @@ func Definition() Schema {
 		},
 		Description: optional.String{},
 		ID:          "urn:ietf:params:scim:schemas:core:2.0:Schema",
-		Name:        optional.String{},
+		Name:        optional.NewString("Schema"),
 	}
 }
 


### PR DESCRIPTION
This [Keycloak Client](https://github.com/suvera/keycloak-scim2-storage) complains...
It isn't required by the RFC, but it doesn't hurt to had it.
