### PR TITLE
Fix error count check when parsing query parameters.

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -660,6 +660,32 @@ func TestServerResourcesGetAllHandlerNegativeCount(t *testing.T) {
 	assertEqual(t, 0, len(response.Resources))
 }
 
+func TestServerResourcesGetAllHandlerNonIntCount(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/Users?count=BadBanana", nil)
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, req)
+
+	assertEqualStatusCode(t, http.StatusBadRequest, rr.Code)
+
+	var response errors.ScimError
+	assertUnmarshalNoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assertEqual(t, http.StatusBadRequest, response.Status)
+	assertEqual(t, "Bad Request. Invalid parameter provided in request: count.", response.Detail)
+}
+
+func TestServerResourcesGetAllHandlerNonIntStartIndex(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/Users?startIndex=BadBanana", nil)
+	rr := httptest.NewRecorder()
+	newTestServer().ServeHTTP(rr, req)
+
+	assertEqualStatusCode(t, http.StatusBadRequest, rr.Code)
+
+	var response errors.ScimError
+	assertUnmarshalNoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assertEqual(t, http.StatusBadRequest, response.Status)
+	assertEqual(t, "Bad Request. Invalid parameter provided in request: startIndex.", response.Detail)
+}
+
 func TestServerResourcesGetHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/Users", nil)
 	rr := httptest.NewRecorder()

--- a/server.go
+++ b/server.go
@@ -189,7 +189,7 @@ func (s Server) parseRequestParams(r *http.Request, refSchema schema.Schema, ref
 		startIndex = defaultStartIndex
 	}
 
-	if len(invalidParams) > 1 {
+	if len(invalidParams) > 0 {
 		scimErr := errors.ScimErrorBadParams(invalidParams)
 		return ListRequestParams{}, &scimErr
 	}


### PR DESCRIPTION
The code should not silently proceed when a single error is found.
Tests added for non-integer count and startIndex query parameters.