### PR TITLE
ListRequestParams: expose validator instead of just plain filter

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/elimity-com/scim/errors"
-	f "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/schema"
 )
 
@@ -306,20 +305,13 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var (
-		validator  = f.NewFilterValidator(params.Filter, schema.Definition())
 		start, end = clamp(params.StartIndex-1, params.Count, len(s.getSchemas()))
 		resources  []interface{}
 	)
-	if params.Filter != nil {
-		if err := validator.Validate(); err != nil {
-			errorHandler(w, r, &errors.ScimErrorInvalidFilter)
-			return
-		}
-	}
 	for _, v := range s.getSchemas()[start:end] {
 		resource := v.ToMap()
-		if params.Filter != nil {
-			if err := validator.PassesFilter(resource); err != nil {
+		if params.FilterValidator != nil {
+			if err := params.FilterValidator.PassesFilter(resource); err != nil {
 				continue
 			}
 		}

--- a/internal/idp_test/azuread_util_test.go
+++ b/internal/idp_test/azuread_util_test.go
@@ -171,7 +171,7 @@ func (a azureADUserResourceHandler) Get(r *http.Request, id string) (scim.Resour
 }
 
 func (a azureADUserResourceHandler) GetAll(r *http.Request, params scim.ListRequestParams) (scim.Page, error) {
-	f := params.Filter.(*filter.AttributeExpression)
+	f := params.FilterValidator.GetFilter().(*filter.AttributeExpression)
 	if f.CompareValue.(string) == "non-existent user" {
 		return scim.Page{}, nil
 	}

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"time"
 
+	f "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
-	"github.com/scim2/filter-parser/v2"
 )
 
 // ListRequestParams request parameters sent to the API via a "GetAll" route.
@@ -17,9 +17,9 @@ type ListRequestParams struct {
 	// A value of "0" indicates that no resource results are to be returned except for "totalResults".
 	Count int
 
-	// Filter represents the parsed and tokenized filter query parameter.
+	// FilterValidator represents the parsed and tokenized filter query parameter.
 	// It is an optional parameter and thus will be nil when the parameter is not present.
-	Filter filter.Expression
+	FilterValidator *f.Validator
 
 	// StartIndex The 1-based index of the first query result. A value less than 1 SHALL be interpreted as 1.
 	StartIndex int

--- a/server.go
+++ b/server.go
@@ -3,7 +3,6 @@ package scim
 import (
 	"fmt"
 	f "github.com/elimity-com/scim/internal/filter"
-	"github.com/scim2/filter-parser/v2"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -19,7 +18,7 @@ const (
 )
 
 // getFilter returns a validated filter if present in the url query, nil otherwise.
-func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (filter.Expression, error) {
+func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (*f.Validator, error) {
 	filter := strings.TrimSpace(r.URL.Query().Get("filter"))
 	if filter == "" {
 		return nil, nil // No filter present.
@@ -32,7 +31,7 @@ func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (f
 	if err := validator.Validate(); err != nil {
 		return nil, err
 	}
-	return validator.GetFilter(), nil
+	return &validator, nil
 }
 
 func getIntQueryParam(r *http.Request, key string, def int) (int, error) {
@@ -200,8 +199,8 @@ func (s Server) parseRequestParams(r *http.Request, refSchema schema.Schema, ref
 	}
 
 	return ListRequestParams{
-		Count:      count,
-		Filter:     reqFilter,
-		StartIndex: startIndex,
+		Count:           count,
+		FilterValidator: reqFilter,
+		StartIndex:      startIndex,
 	}, nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elimity-com/scim"
 	"github.com/elimity-com/scim/errors"
-	internal "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
@@ -156,8 +155,7 @@ func (h testResourceHandler) GetAll(r *http.Request, params scim.ListRequestPara
 			break
 		}
 
-		validator := internal.NewFilterValidator(params.Filter, h.schema)
-		if err := validator.PassesFilter(v.attributes); err != nil {
+		if err := params.FilterValidator.PassesFilter(v.attributes); err != nil {
 			continue
 		}
 


### PR DESCRIPTION
Filter can be retrieved with GetFilter() - but having the validator
allows for one to call PassesFilter() in the GetAll handler functions.