### PR TITLE
Add logging facility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,9 @@ resourceTypes := []ResourceType{
 
 ### 4. Create Server
 ```go
-server := Server{
-    Config:        config,
-    ResourceTypes: resourceTypes,
-}
+server := NewServer(config, resourceTypes, logging.NullLogger{})
 ```
+To log messages to standard error, you can use `logging.NewSimpleLogger(os.Stderr)` as the third argument to `NewServer`.
 
 ## Addition Checks/Tests
 Not everything can be checked by the SCIM server itself.

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,21 +1,25 @@
 package scim
 
 import (
+	"github.com/elimity-com/scim/logging"
 	"log"
 	"net/http"
+	"os"
 )
 
 func ExampleNewServer() {
-	log.Fatal(http.ListenAndServe(":7643", Server{
-		Config:        ServiceProviderConfig{},
-		ResourceTypes: nil,
-	}))
+	log.Fatal(http.ListenAndServe(":7643", NewServer(
+		ServiceProviderConfig{},
+		nil,
+		logging.NewSimpleLogger(os.Stderr),
+	)))
 }
 
 func ExampleNewServer_basePath() {
-	http.Handle("/scim/", http.StripPrefix("/scim", Server{
-		Config:        ServiceProviderConfig{},
-		ResourceTypes: nil,
-	}))
+	http.Handle("/scim/", http.StripPrefix("/scim", NewServer(
+		ServiceProviderConfig{},
+		nil,
+		logging.NewSimpleLogger(os.Stderr),
+	)))
 	log.Fatal(http.ListenAndServe(":7643", nil))
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -2,6 +2,7 @@ package scim_test
 
 import (
 	"encoding/json"
+	"github.com/elimity-com/scim/logging"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -130,8 +131,9 @@ func Test_User_Filter(t *testing.T) {
 }
 
 func newTestServerForFilter() scim.Server {
-	return scim.Server{
-		ResourceTypes: []scim.ResourceType{
+	return scim.NewServer(
+		scim.ServiceProviderConfig{},
+		[]scim.ResourceType{
 			{
 				ID:          optional.NewString("User"),
 				Name:        "User",
@@ -161,5 +163,6 @@ func newTestServerForFilter() scim.Server {
 				},
 			},
 		},
-	}
+		logging.NullLogger{},
+	)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/elimity-com/scim/schema"
 )
 
-func errorHandler(w http.ResponseWriter, _ *http.Request, scimErr *errors.ScimError) {
+func ErrorHandler(w http.ResponseWriter, _ *http.Request, scimErr *errors.ScimError) {
 	raw, err := json.Marshal(scimErr)
 	if err != nil {
 		log.Fatalf("failed marshaling scim error: %v", err)
@@ -22,32 +22,32 @@ func errorHandler(w http.ResponseWriter, _ *http.Request, scimErr *errors.ScimEr
 	}
 }
 
-// resourceDeleteHandler receives an HTTP DELETE request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
+// ResourceDeleteHandler receives an HTTP DELETE request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
 // where "{id}" is a resource identifier to delete a known resource.
-func (s Server) resourceDeleteHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
+func (s Server) ResourceDeleteHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
 	deleteErr := resourceType.Handler.Delete(r, id)
 	if deleteErr != nil {
 		scimErr := errors.CheckScimError(deleteErr, http.MethodDelete)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// resourceGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
+// ResourceGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}",
 // where "{id}" is a resource identifier to retrieve a known resource.
-func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
+func (s Server) ResourceGetHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
 	resource, getErr := resourceType.Handler.Get(r, id)
 	if getErr != nil {
 		scimErr := errors.CheckScimError(getErr, http.MethodGet)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	raw, err := json.Marshal(resource.response(resourceType))
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource: %v", err)
 		return
 	}
@@ -62,19 +62,19 @@ func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id st
 	}
 }
 
-// resourcePatchHandler receives an HTTP PATCH to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}", where
+// ResourcePatchHandler receives an HTTP PATCH to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}", where
 // "{id}" is a resource identifier to replace a resource's attributes.
-func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
+func (s Server) ResourcePatchHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
 	patch, scimErr := resourceType.validatePatch(r)
 	if scimErr != nil {
-		errorHandler(w, r, scimErr)
+		ErrorHandler(w, r, scimErr)
 		return
 	}
 
 	resource, patchErr := resourceType.Handler.Patch(r, id, patch)
 	if patchErr != nil {
 		scimErr := errors.CheckScimError(patchErr, http.MethodPatch)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
@@ -85,7 +85,7 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 
 	raw, err := json.Marshal(resource.response(resourceType))
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource: %v", err)
 		return
 	}
@@ -102,27 +102,27 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 	}
 }
 
-// resourcePostHandler receives an HTTP POST request to the resource endpoint, such as "/Users" or "/Groups", as
+// ResourcePostHandler receives an HTTP POST request to the resource endpoint, such as "/Users" or "/Groups", as
 // defined by the associated resource type endpoint discovery to create new resources.
-func (s Server) resourcePostHandler(w http.ResponseWriter, r *http.Request, resourceType ResourceType) {
+func (s Server) ResourcePostHandler(w http.ResponseWriter, r *http.Request, resourceType ResourceType) {
 	data, _ := readBody(r)
 
 	attributes, scimErr := resourceType.validate(data)
 	if scimErr != nil {
-		errorHandler(w, r, scimErr)
+		ErrorHandler(w, r, scimErr)
 		return
 	}
 
 	resource, postErr := resourceType.Handler.Create(r, attributes)
 	if postErr != nil {
 		scimErr := errors.CheckScimError(postErr, http.MethodPost)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	raw, err := json.Marshal(resource.response(resourceType))
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource: %v", err)
 		return
 	}
@@ -139,27 +139,27 @@ func (s Server) resourcePostHandler(w http.ResponseWriter, r *http.Request, reso
 	}
 }
 
-// resourcePutHandler receives an HTTP PUT to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}", where
+// ResourcePutHandler receives an HTTP PUT to the resource endpoint, e.g., "/Users/{id}" or "/Groups/{id}", where
 // "{id}" is a resource identifier to replace a resource's attributes.
-func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
+func (s Server) ResourcePutHandler(w http.ResponseWriter, r *http.Request, id string, resourceType ResourceType) {
 	data, _ := readBody(r)
 
 	attributes, scimErr := resourceType.validate(data)
 	if scimErr != nil {
-		errorHandler(w, r, scimErr)
+		ErrorHandler(w, r, scimErr)
 		return
 	}
 
 	resource, putError := resourceType.Handler.Replace(r, id, attributes)
 	if putError != nil {
 		scimErr := errors.CheckScimError(putError, http.MethodPut)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	raw, err := json.Marshal(resource.response(resourceType))
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource: %v", err)
 		return
 	}
@@ -174,9 +174,9 @@ func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id st
 	}
 }
 
-// resourceTypeHandler receives an HTTP GET to retrieve individual resource types which can be returned by appending the
+// ResourceTypeHandler receives an HTTP GET to retrieve individual resource types which can be returned by appending the
 // resource types name to the /ResourceTypes endpoint. For example: "/ResourceTypes/User".
-func (s Server) resourceTypeHandler(w http.ResponseWriter, r *http.Request, name string) {
+func (s Server) ResourceTypeHandler(w http.ResponseWriter, r *http.Request, name string) {
 	var resourceType ResourceType
 	for _, r := range s.ResourceTypes {
 		if r.Name == name {
@@ -187,13 +187,13 @@ func (s Server) resourceTypeHandler(w http.ResponseWriter, r *http.Request, name
 
 	if resourceType.Name != name {
 		scimErr := errors.ScimErrorResourceNotFound(name)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	raw, err := json.Marshal(resourceType.getRaw())
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource type: %v", err)
 		return
 	}
@@ -204,13 +204,13 @@ func (s Server) resourceTypeHandler(w http.ResponseWriter, r *http.Request, name
 	}
 }
 
-// resourceTypesHandler receives an HTTP GET to this endpoint, "/ResourceTypes", which is used to discover the types of
+// ResourceTypesHandler receives an HTTP GET to this endpoint, "/ResourceTypes", which is used to discover the types of
 // resources available on a SCIM service provider (e.g., Users and Groups).  Each resource type defines the endpoints,
 // the core schema URI that defines the resource, and any supported schema extensions.
-func (s Server) resourceTypesHandler(w http.ResponseWriter, r *http.Request) {
+func (s Server) ResourceTypesHandler(w http.ResponseWriter, r *http.Request) {
 	params, paramsErr := s.parseRequestParams(r, schema.ResourceTypeSchema())
 	if paramsErr != nil {
-		errorHandler(w, r, paramsErr)
+		ErrorHandler(w, r, paramsErr)
 		return
 	}
 
@@ -227,7 +227,7 @@ func (s Server) resourceTypesHandler(w http.ResponseWriter, r *http.Request) {
 		Resources:    resources,
 	})
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling list response: %v", err)
 		return
 	}
@@ -238,19 +238,19 @@ func (s Server) resourceTypesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// resourcesGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users" or "/Groups", to retrieve
+// ResourcesGetHandler receives an HTTP GET request to the resource endpoint, e.g., "/Users" or "/Groups", to retrieve
 // all known resources.
-func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, resourceType ResourceType) {
+func (s Server) ResourcesGetHandler(w http.ResponseWriter, r *http.Request, resourceType ResourceType) {
 	params, paramsErr := s.parseRequestParams(r, resourceType.Schema, resourceType.getSchemaExtensions()...)
 	if paramsErr != nil {
-		errorHandler(w, r, paramsErr)
+		ErrorHandler(w, r, paramsErr)
 		return
 	}
 
 	page, getError := resourceType.Handler.GetAll(r, params)
 	if getError != nil {
 		scimErr := errors.CheckScimError(getError, http.MethodGet)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
@@ -261,7 +261,7 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 		ItemsPerPage: params.Count,
 	})
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshalling list response: %v", err)
 		return
 	}
@@ -272,19 +272,19 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 	}
 }
 
-// schemaHandler receives an HTTP GET to retrieve individual schema definitions which can be returned by appending the
+// SchemaHandler receives an HTTP GET to retrieve individual schema definitions which can be returned by appending the
 // schema URI to the /Schemas endpoint. For example: "/Schemas/urn:ietf:params:scim:schemas:core:2.0:User".
-func (s Server) schemaHandler(w http.ResponseWriter, r *http.Request, id string) {
+func (s Server) SchemaHandler(w http.ResponseWriter, r *http.Request, id string) {
 	getSchema := s.getSchema(id)
 	if getSchema.ID != id {
 		scimErr := errors.ScimErrorResourceNotFound(id)
-		errorHandler(w, r, &scimErr)
+		ErrorHandler(w, r, &scimErr)
 		return
 	}
 
 	raw, err := json.Marshal(getSchema)
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling schema: %v", err)
 		return
 	}
@@ -295,12 +295,12 @@ func (s Server) schemaHandler(w http.ResponseWriter, r *http.Request, id string)
 	}
 }
 
-// schemasHandler receives an HTTP GET to retrieve information about resource schemas supported by a SCIM service
+// SchemasHandler receives an HTTP GET to retrieve information about resource schemas supported by a SCIM service
 // provider. An HTTP GET to the endpoint "/Schemas" returns all supported schemas in ListResponse format.
-func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
+func (s Server) SchemasHandler(w http.ResponseWriter, r *http.Request) {
 	params, paramsErr := s.parseRequestParams(r, schema.Definition())
 	if paramsErr != nil {
-		errorHandler(w, r, paramsErr)
+		ErrorHandler(w, r, paramsErr)
 		return
 	}
 
@@ -325,7 +325,7 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 		Resources:    resources,
 	})
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling list response: %v", err)
 		return
 	}
@@ -336,12 +336,12 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// serviceProviderConfigHandler receives an HTTP GET to this endpoint will return a JSON structure that describes the
+// ServiceProviderConfigHandler receives an HTTP GET to this endpoint will return a JSON structure that describes the
 // SCIM specification features available on a service provider.
-func (s Server) serviceProviderConfigHandler(w http.ResponseWriter, r *http.Request) {
+func (s Server) ServiceProviderConfigHandler(w http.ResponseWriter, r *http.Request) {
 	raw, err := json.Marshal(s.Config.getRaw())
 	if err != nil {
-		errorHandler(w, r, &errors.ScimErrorInternal)
+		ErrorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling service provider config: %v", err)
 		return
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/elimity-com/scim/errors"
-	f "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/schema"
 )
 
@@ -306,20 +305,13 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var (
-		validator  = f.NewFilterValidator(params.Filter, schema.Definition())
 		start, end = clamp(params.StartIndex-1, params.Count, len(s.getSchemas()))
 		resources  []interface{}
 	)
-	if params.Filter != nil {
-		if err := validator.Validate(); err != nil {
-			errorHandler(w, r, &errors.ScimErrorInvalidFilter)
-			return
-		}
-	}
 	for _, v := range s.getSchemas()[start:end] {
 		resource := v.ToMap()
-		if params.Filter != nil {
-			if err := validator.PassesFilter(resource); err != nil {
+		if params.FilterValidator != nil {
+			if err := params.FilterValidator.PassesFilter(resource); err != nil {
 				continue
 			}
 		}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/elimity-com/scim/logging"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -933,9 +934,9 @@ func newTestResourceHandler() ResourceHandler {
 func newTestServer() Server {
 	userSchema := getUserSchema()
 	userSchemaExtension := getUserExtensionSchema()
-	return Server{
-		Config: ServiceProviderConfig{},
-		ResourceTypes: []ResourceType{
+	return NewServer(
+		ServiceProviderConfig{},
+		[]ResourceType{
 			{
 				ID:          optional.NewString("User"),
 				Name:        "User",
@@ -964,5 +965,6 @@ func newTestServer() Server {
 				Handler:     newTestResourceHandler(),
 			},
 		},
-	}
+		logging.NullLogger{},
+	)
 }

--- a/internal/idp_test/azuread_util_test.go
+++ b/internal/idp_test/azuread_util_test.go
@@ -171,7 +171,7 @@ func (a azureADUserResourceHandler) Get(r *http.Request, id string) (scim.Resour
 }
 
 func (a azureADUserResourceHandler) GetAll(r *http.Request, params scim.ListRequestParams) (scim.Page, error) {
-	f := params.Filter.(*filter.AttributeExpression)
+	f := params.FilterValidator.GetFilter().(*filter.AttributeExpression)
 	if f.CompareValue.(string) == "non-existent user" {
 		return scim.Page{}, nil
 	}

--- a/internal/idp_test/azuread_util_test.go
+++ b/internal/idp_test/azuread_util_test.go
@@ -1,6 +1,7 @@
 package idp_test
 
 import (
+	"github.com/elimity-com/scim/logging"
 	"net/http"
 	"time"
 
@@ -17,11 +18,11 @@ var azureCreatedTime = time.Date(
 )
 
 func newAzureADTestServer() scim.Server {
-	return scim.Server{
-		Config: scim.ServiceProviderConfig{
+	return scim.NewServer(
+		scim.ServiceProviderConfig{
 			MaxResults: 20,
 		},
-		ResourceTypes: []scim.ResourceType{
+		[]scim.ResourceType{
 			{
 				ID:          optional.NewString("User"),
 				Name:        "User",
@@ -43,7 +44,8 @@ func newAzureADTestServer() scim.Server {
 				Handler:     azureADGroupResourceHandler{},
 			},
 		},
-	}
+		logging.NullLogger{},
+	)
 }
 
 type azureADGroupResourceHandler struct{}

--- a/internal/idp_test/okta_util_test.go
+++ b/internal/idp_test/okta_util_test.go
@@ -1,6 +1,7 @@
 package idp_test
 
 import (
+	"github.com/elimity-com/scim/logging"
 	"net/http"
 
 	"github.com/elimity-com/scim"
@@ -10,8 +11,9 @@ import (
 )
 
 func newOktaTestServer() scim.Server {
-	return scim.Server{
-		ResourceTypes: []scim.ResourceType{
+	return scim.NewServer(
+		scim.ServiceProviderConfig{},
+		[]scim.ResourceType{
 			{
 				ID:          optional.NewString("User"),
 				Name:        "User",
@@ -30,7 +32,8 @@ func newOktaTestServer() scim.Server {
 				Handler:     oktaGroupResourceHandler{},
 			},
 		},
-	}
+		logging.NullLogger{},
+	)
 }
 
 type oktaGroupResourceHandler struct{}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,66 @@
+package logging
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+type Logger interface {
+	Debugf(format string, args ...interface{})    // Debug message
+	Infof(format string, args ...interface{})     // Information message
+	Warningf(format string, args ...interface{})  // Warning message
+	Errorf(format string, args ...interface{})    // Error message
+	Criticalf(format string, args ...interface{}) // Critical message
+}
+
+// NullLogger implements a no-op Logger
+type NullLogger struct{}
+
+func (n NullLogger) Debugf(format string, args ...interface{})    {}
+func (n NullLogger) Infof(format string, args ...interface{})     {}
+func (n NullLogger) Warningf(format string, args ...interface{})  {}
+func (n NullLogger) Errorf(format string, args ...interface{})    {}
+func (n NullLogger) Criticalf(format string, args ...interface{}) {}
+
+//SimpleLogger implements a Logger that directs output to an io.Writer
+type SimpleLogger struct {
+	DebugLogger    *log.Logger
+	InfoLogger     *log.Logger
+	WarningLogger  *log.Logger
+	ErrorLogger    *log.Logger
+	CriticalLogger *log.Logger
+}
+
+func NewSimpleLogger(out io.Writer) Logger {
+	if out == nil {
+		out = os.Stderr
+	}
+	return SimpleLogger{
+		DebugLogger:    log.New(out, "DEBUG: ", log.LstdFlags|log.Lshortfile|log.LUTC),
+		InfoLogger:     log.New(out, "INFO: ", log.LstdFlags|log.Lshortfile|log.LUTC),
+		WarningLogger:  log.New(out, "WARNING: ", log.LstdFlags|log.Lshortfile|log.LUTC),
+		ErrorLogger:    log.New(out, "ERROR: ", log.LstdFlags|log.Lshortfile|log.LUTC),
+		CriticalLogger: log.New(out, "CRITICAL: ", log.LstdFlags|log.Lshortfile|log.LUTC),
+	}
+}
+
+func (l SimpleLogger) Debugf(format string, args ...interface{}) {
+	l.DebugLogger.Printf(format, args...)
+}
+
+func (l SimpleLogger) Infof(format string, args ...interface{}) {
+	l.InfoLogger.Printf(format, args...)
+}
+
+func (l SimpleLogger) Warningf(format string, args ...interface{}) {
+	l.WarningLogger.Printf(format, args...)
+}
+
+func (l SimpleLogger) Errorf(format string, args ...interface{}) {
+	l.ErrorLogger.Printf(format, args...)
+}
+
+func (l SimpleLogger) Criticalf(format string, args ...interface{}) {
+	l.CriticalLogger.Printf(format, args...)
+}

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"time"
 
+	f "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
-	"github.com/scim2/filter-parser/v2"
 )
 
 // ListRequestParams request parameters sent to the API via a "GetAll" route.
@@ -17,9 +17,9 @@ type ListRequestParams struct {
 	// A value of "0" indicates that no resource results are to be returned except for "totalResults".
 	Count int
 
-	// Filter represents the parsed and tokenized filter query parameter.
+	// FilterValidator represents the parsed and tokenized filter query parameter.
 	// It is an optional parameter and thus will be nil when the parameter is not present.
-	Filter filter.Expression
+	FilterValidator *f.Validator
 
 	// StartIndex The 1-based index of the first query result. A value less than 1 SHALL be interpreted as 1.
 	StartIndex int

--- a/server.go
+++ b/server.go
@@ -3,7 +3,6 @@ package scim
 import (
 	"fmt"
 	f "github.com/elimity-com/scim/internal/filter"
-	"github.com/scim2/filter-parser/v2"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -19,7 +18,7 @@ const (
 )
 
 // getFilter returns a validated filter if present in the url query, nil otherwise.
-func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (filter.Expression, error) {
+func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (*f.Validator, error) {
 	filter := strings.TrimSpace(r.URL.Query().Get("filter"))
 	if filter == "" {
 		return nil, nil // No filter present.
@@ -32,7 +31,7 @@ func getFilter(r *http.Request, s schema.Schema, extensions ...schema.Schema) (f
 	if err := validator.Validate(); err != nil {
 		return nil, err
 	}
-	return validator.GetFilter(), nil
+	return &validator, nil
 }
 
 func getIntQueryParam(r *http.Request, key string, def int) (int, error) {
@@ -200,8 +199,8 @@ func (s Server) parseRequestParams(r *http.Request, refSchema schema.Schema, ref
 	}
 
 	return ListRequestParams{
-		Count:      count,
-		Filter:     reqFilter,
-		StartIndex: startIndex,
+		Count:           count,
+		FilterValidator: reqFilter,
+		StartIndex:      startIndex,
 	}, nil
 }

--- a/server.go
+++ b/server.go
@@ -67,24 +67,24 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case path == "/Me":
-		errorHandler(w, r, &errors.ScimError{
+		ErrorHandler(w, r, &errors.ScimError{
 			Status: http.StatusNotImplemented,
 		})
 		return
 	case path == "/Schemas" && r.Method == http.MethodGet:
-		s.schemasHandler(w, r)
+		s.SchemasHandler(w, r)
 		return
 	case strings.HasPrefix(path, "/Schemas/") && r.Method == http.MethodGet:
-		s.schemaHandler(w, r, strings.TrimPrefix(path, "/Schemas/"))
+		s.SchemaHandler(w, r, strings.TrimPrefix(path, "/Schemas/"))
 		return
 	case path == "/ResourceTypes" && r.Method == http.MethodGet:
-		s.resourceTypesHandler(w, r)
+		s.ResourceTypesHandler(w, r)
 		return
 	case strings.HasPrefix(path, "/ResourceTypes/") && r.Method == http.MethodGet:
-		s.resourceTypeHandler(w, r, strings.TrimPrefix(path, "/ResourceTypes/"))
+		s.ResourceTypeHandler(w, r, strings.TrimPrefix(path, "/ResourceTypes/"))
 		return
 	case path == "/ServiceProviderConfig":
-		s.serviceProviderConfigHandler(w, r)
+		s.ServiceProviderConfigHandler(w, r)
 		return
 	}
 
@@ -92,10 +92,10 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if path == resourceType.Endpoint {
 			switch r.Method {
 			case http.MethodPost:
-				s.resourcePostHandler(w, r, resourceType)
+				s.ResourcePostHandler(w, r, resourceType)
 				return
 			case http.MethodGet:
-				s.resourcesGetHandler(w, r, resourceType)
+				s.ResourcesGetHandler(w, r, resourceType)
 				return
 			}
 		}
@@ -108,22 +108,22 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			switch r.Method {
 			case http.MethodGet:
-				s.resourceGetHandler(w, r, id, resourceType)
+				s.ResourceGetHandler(w, r, id, resourceType)
 				return
 			case http.MethodPut:
-				s.resourcePutHandler(w, r, id, resourceType)
+				s.ResourcePutHandler(w, r, id, resourceType)
 				return
 			case http.MethodPatch:
-				s.resourcePatchHandler(w, r, id, resourceType)
+				s.ResourcePatchHandler(w, r, id, resourceType)
 				return
 			case http.MethodDelete:
-				s.resourceDeleteHandler(w, r, id, resourceType)
+				s.ResourceDeleteHandler(w, r, id, resourceType)
 				return
 			}
 		}
 	}
 
-	errorHandler(w, r, &errors.ScimError{
+	ErrorHandler(w, r, &errors.ScimError{
 		Detail: "Specified endpoint does not exist.",
 		Status: http.StatusNotFound,
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package scim_test
 
 import (
 	"fmt"
+	"github.com/elimity-com/scim/logging"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -40,8 +41,8 @@ func externalID(attributes scim.ResourceAttributes) optional.String {
 //   e.g. if a member gets added, does this entity exist?
 
 func newTestServer() scim.Server {
-	return scim.Server{
-		ResourceTypes: []scim.ResourceType{
+	return scim.NewServer(scim.ServiceProviderConfig{},
+		[]scim.ResourceType{
 			{
 				ID:          optional.NewString("User"),
 				Name:        "User",
@@ -69,7 +70,8 @@ func newTestServer() scim.Server {
 				},
 			},
 		},
-	}
+		logging.NullLogger{},
+	)
 }
 
 // testData represents a resource entity.

--- a/server_test.go
+++ b/server_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/elimity-com/scim"
 	"github.com/elimity-com/scim/errors"
-	internal "github.com/elimity-com/scim/internal/filter"
 	"github.com/elimity-com/scim/optional"
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
@@ -156,8 +155,7 @@ func (h testResourceHandler) GetAll(r *http.Request, params scim.ListRequestPara
 			break
 		}
 
-		validator := internal.NewFilterValidator(params.Filter, h.schema)
-		if err := validator.PassesFilter(v.attributes); err != nil {
+		if err := params.FilterValidator.PassesFilter(v.attributes); err != nil {
 			continue
 		}
 


### PR DESCRIPTION
In more than one occasion we had to inspect the payload the IdP
was sending, and that was pretty much impossible.
 
One can add logging in resource handlers, but if incomplete data
is sent, the resource handler code is not hit, and teh response
is served back by the Server handlers.
    
Logging the payload (for patch/put/create) with Debugf will
greatly help.
