### PR TITLE
Rename getRaw to ToMap to expose in API

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -192,7 +192,7 @@ func (s Server) resourceTypeHandler(w http.ResponseWriter, r *http.Request, name
 		return
 	}
 
-	raw, err := json.Marshal(resourceType.getRaw())
+	raw, err := json.Marshal(resourceType.ToMap())
 	if err != nil {
 		errorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling resource type: %v", err)
@@ -218,7 +218,7 @@ func (s Server) resourceTypesHandler(w http.ResponseWriter, r *http.Request) {
 	start, end := clamp(params.StartIndex-1, params.Count, len(s.ResourceTypes))
 	var resources []interface{}
 	for _, v := range s.ResourceTypes[start:end] {
-		resources = append(resources, v.getRaw())
+		resources = append(resources, v.ToMap())
 	}
 
 	raw, err := json.Marshal(listResponse{
@@ -347,7 +347,7 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 // serviceProviderConfigHandler receives an HTTP GET to this endpoint will return a JSON structure that describes the
 // SCIM specification features available on a service provider.
 func (s Server) serviceProviderConfigHandler(w http.ResponseWriter, r *http.Request) {
-	raw, err := json.Marshal(s.Config.getRaw())
+	raw, err := json.Marshal(s.Config.ToMap())
 	if err != nil {
 		errorHandler(w, r, &errors.ScimErrorInternal)
 		log.Fatalf("failed marshaling service provider config: %v", err)

--- a/resource_type.go
+++ b/resource_type.go
@@ -38,7 +38,7 @@ type ResourceType struct {
 	Handler ResourceHandler
 }
 
-func (t ResourceType) getRaw() map[string]interface{} {
+func (t ResourceType) ToMap() map[string]interface{} {
 	return map[string]interface{}{
 		"schemas":          []string{"urn:ietf:params:scim:schemas:core:2.0:ResourceType"},
 		"id":               t.ID.Value(),

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -61,7 +61,7 @@ func (config ServiceProviderConfig) getItemsPerPage() int {
 	return config.MaxResults
 }
 
-func (config ServiceProviderConfig) getRaw() map[string]interface{} {
+func (config ServiceProviderConfig) ToMap() map[string]interface{} {
 	return map[string]interface{}{
 		"schemas":          []string{"urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"},
 		"documentationUri": config.DocumentationURI.Value(),


### PR DESCRIPTION
This also makes ServiceProviderConfig and ResourceType match the ToMap method on Schema.

For our use-case, the server/handlers don't fit neatly in our existing HTTP server, so I'm wanting to use the objects without that part. In order to marshal properly we need access to these currently internal methods.