### PR TITLE
Add Primary Sub-Attribute for Address in User Schema 

### DIFF
--- a/internal/patch/replace_test.go
+++ b/internal/patch/replace_test.go
@@ -89,5 +89,5 @@ func Example_replaceWorkAddress() {
 	validator, _ := NewValidator(operation, schema.CoreUserSchema())
 	fmt.Println(validator.Validate())
 	// Output:
-	// [map[country:BE locality:ExampleCity postalCode:0001 streetAddress:ExampleStreet 1 type:work]] <nil>
+	// [map[country:BE locality:ExampleCity postalCode:0001 primary:true streetAddress:ExampleStreet 1 type:work]] <nil>
 }

--- a/schema/schemas.go
+++ b/schema/schemas.go
@@ -429,6 +429,10 @@ func CoreUserSchema() Schema {
 						Description:     optional.NewString("A label indicating the attribute's function, e.g., 'work' or 'home'."),
 						Name:            "type",
 					}),
+					SimpleBooleanParams(BooleanParams{
+						Description: optional.NewString("A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred address. The primary attribute value 'true' MUST appear no more than once."),
+						Name:        "primary",
+					}),
 				},
 			}),
 			ComplexCoreAttribute(ComplexParams{

--- a/schema/testdata/user_schema.json
+++ b/schema/testdata/user_schema.json
@@ -530,6 +530,15 @@
           "returned": "default",
           "type": "string",
           "uniqueness": "none"
+        },
+        {
+          "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g., the preferred address. The primary attribute value 'true' MUST appear no more than once.",
+          "multiValued": false,
+          "mutability": "readWrite",
+          "name": "primary",
+          "required": false,
+          "returned": "default",
+          "type": "boolean"
         }
       ],
       "type": "complex"


### PR DESCRIPTION
Hi,
The following patch request fails because of a bug in [User Schema](https://github.com/elimity-com/scim/blob/15165b1a61c853d4e5e9ccfa54cfb2efc92eb733/schema/schemas.go#L219).

```
{
  "Operations": [
    {
      "op": "replace",
      "path": "addresses[type eq \"work\"].primary",
      "value": true
     },
  ]
}
```
The primary subAttribute under address is actually missing, but it's present in the SCIM Core Schema [RFC](https://www.rfc-editor.org/rfc/rfc7643#:~:text=%22addresses%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22type%22%3A%20%22work%22%2C%0A%20%20%20%20%20%20%22streetAddress%22%3A%20%22100%20Universal%20City%20Plaza%22%2C%0A%20%20%20%20%20%20%22locality%22%3A%20%22Hollywood%22%2C%0A%20%20%20%20%20%20%22region%22%3A%20%22CA%22%2C%0A%20%20%20%20%20%20%22postalCode%22%3A%20%2291608%22%2C%0A%20%20%20%20%20%20%22country%22%3A%20%22USA%22%2C%0A%20%20%20%20%20%20%22formatted%22%3A%20%22100%20Universal%20City%20Plaza%5CnHollywood%2C%20CA%2091608%20USA%22%2C%0A%20%20%20%20%20%20%22primary%22%3A%20true%0A%20%20%20%20%7D%2C), which is the real issue.
I have added primary attribute for the address in the Core User Schema and updated relevant test method changes as well.