### PR TITLE
Add ability to trim customized path prefix

### DIFF
--- a/server.go
+++ b/server.go
@@ -2,12 +2,13 @@ package scim
 
 import (
 	"fmt"
-	f "github.com/elimity-com/scim/internal/filter"
-	"github.com/scim2/filter-parser/v2"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	f "github.com/elimity-com/scim/internal/filter"
+	"github.com/scim2/filter-parser/v2"
 
 	"github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/schema"
@@ -64,7 +65,7 @@ type Server struct {
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/scim+json")
 
-	path := strings.TrimPrefix(r.URL.Path, "/v2")
+	path := strings.TrimPrefix(r.URL.Path, s.Config.PathPrefix)
 
 	switch {
 	case path == "/Me":

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -40,6 +40,8 @@ const (
 // ServiceProviderConfig enables a service provider to discover SCIM specification features in a standardized form as
 // well as provide additional implementation details to clients.
 type ServiceProviderConfig struct {
+	// PathPrefix is the prefix in the SCIM API URL used to trim the request path in ServeHTTP
+	PathPrefix string
 	// DocumentationURI is an HTTP-addressable URL pointing to the service provider's human-consumable help
 	// documentation.
 	DocumentationURI optional.String


### PR DESCRIPTION
when base URL is complex, it's hard to trim. With this change we can define base URL and trim it when needed. 