### PR TITLE
Accept nil values for attribiutes defined as required and read-only.

### DIFF
--- a/schema/core.go
+++ b/schema/core.go
@@ -305,7 +305,7 @@ func (a *CoreAttribute) getRawAttributes() map[string]interface{} {
 func (a CoreAttribute) validate(attribute interface{}) (interface{}, *errors.ScimError) {
 	// whether or not the attribute is required.
 	if attribute == nil {
-		if !a.required {
+		if !a.required || a.mutability == attributeMutabilityReadOnly {
 			return nil, nil
 		}
 

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -17,6 +17,11 @@ var testSchema = Schema{
 			Name:     "required",
 			Required: true,
 		})),
+		SimpleCoreAttribute(SimpleStringParams(StringParams{
+			Name:       "requiredReadOnly",
+			Required:   true,
+			Mutability: AttributeMutabilityReadOnly(),
+		})),
 		SimpleCoreAttribute(SimpleBooleanParams(BooleanParams{
 			MultiValued: true,
 			Name:        "booleans",
@@ -110,7 +115,8 @@ func TestResourceInvalid(t *testing.T) {
 func TestValidValidation(t *testing.T) {
 	for _, test := range []map[string]interface{}{
 		{
-			"required": "present",
+			"required":         "present",
+			"requiredReadOnly": "ignoreme",
 			"booleans": []interface{}{
 				true,
 			},
@@ -125,6 +131,17 @@ func TestValidValidation(t *testing.T) {
 			"decimal":       -2.1e5,
 			"integerNumber": json.Number("11"),
 			"decimalNumber": json.Number("11.12"),
+		},
+		{
+			"required": "present",
+			"booleans": []interface{}{
+				true,
+			},
+			"complex": []interface{}{
+				map[string]interface{}{
+					"sub": "present",
+				},
+			},
 		},
 	} {
 		if _, scimErr := testSchema.Validate(test); scimErr != nil {

--- a/schema/testdata/schema_test.json
+++ b/schema/testdata/schema_test.json
@@ -12,6 +12,17 @@
       "uniqueness": "none"
     },
     {
+      "caseExact": false,
+      "description": "",
+      "multiValued": false,
+      "mutability": "readOnly",
+      "name": "requiredReadOnly",
+      "required": true,
+      "returned": "default",
+      "type": "string",
+      "uniqueness": "none"
+    },
+    {
       "description": "",
       "multiValued": true,
       "mutability": "readWrite",
@@ -120,7 +131,9 @@
       "uniqueness": "none"
     }
   ],
-  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Schema"],
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:Schema"
+  ],
   "description": "",
   "id": "empty",
   "name": "test"


### PR DESCRIPTION
This is particularly relevant for the id attribute, which is typically defined as required and read-only. It is assigned by the IdP, and required to be returned. It should not be required to be specified on POST/PUT/PATCH.