### PR TITLE
Use json.Number to decode patch operations

### DIFF
--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -41,7 +42,11 @@ func NewValidator(patchReq string, s schema.Schema, extensions ...schema.Schema)
 		Path  string
 		Value interface{}
 	}
-	if err := json.Unmarshal([]byte(patchReq), &operation); err != nil {
+
+	// Decode a number into a json.Number instead of floag64
+	d := json.NewDecoder(bytes.NewBufferString(patchReq))
+	d.UseNumber()
+	if err := d.Decode(&operation); err != nil {
 		return OperationValidator{}, err
 	}
 

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -2,9 +2,10 @@ package patch
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
-	"testing"
 )
 
 func TestNewPathValidator(t *testing.T) {
@@ -29,6 +30,51 @@ func TestNewPathValidator(t *testing.T) {
 		op := `{"op":"add","path":"invalid pr","value":"value"}`
 		if _, err := NewValidator(op, patchSchema); err == nil {
 			t.Error("expected JSON error, got none")
+		}
+	})
+	t.Run("Valid integer", func(t *testing.T) {
+		op := `{"op":"add","path":"attr2","value":1234}`
+		validator, err := NewValidator(op, patchSchema)
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		v, err := validator.Validate()
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		n, ok := v.(int64)
+		if !ok {
+			t.Errorf("unexpected type, got %T", v)
+			return
+		}
+		if n != 1234 {
+			t.Errorf("unexpected integer, got %d", n)
+			return
+		}
+	})
+
+	t.Run("Valid float64", func(t *testing.T) {
+		op := `{"op":"add","path":"attr3","value":12.34}`
+		validator, err := NewValidator(op, patchSchema)
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		v, err := validator.Validate()
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		n, ok := v.(float64)
+		if !ok {
+			t.Errorf("unexpected type, got %T", v)
+			return
+		}
+		if n != 12.34 {
+			t.Errorf("unexpected integer, got %f", n)
+			return
 		}
 	})
 }

--- a/internal/patch/schema_test.go
+++ b/internal/patch/schema_test.go
@@ -14,6 +14,14 @@ var (
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name: "attr1",
 			})),
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr2",
+				Type: schema.AttributeTypeInteger(),
+			})),
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr3",
+				Type: schema.AttributeTypeDecimal(),
+			})),
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name:        "multiValued",
 				MultiValued: true,


### PR DESCRIPTION
### Description

This commit fixes the decoding of integer attributes in patches. Without this change, integer attributes are decoded as float64, causing a schema validation error.