### PR TITLE
Allow strings as numbers and booleans

### DIFF
--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -41,7 +42,11 @@ func NewValidator(patchReq string, s schema.Schema, extensions ...schema.Schema)
 		Path  string
 		Value interface{}
 	}
-	if err := json.Unmarshal([]byte(patchReq), &operation); err != nil {
+
+	// Decode a number into a json.Number instead of floag64
+	d := json.NewDecoder(bytes.NewBufferString(patchReq))
+	d.UseNumber()
+	if err := d.Decode(&operation); err != nil {
 		return OperationValidator{}, err
 	}
 

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -33,48 +33,91 @@ func TestNewPathValidator(t *testing.T) {
 		}
 	})
 	t.Run("Valid integer", func(t *testing.T) {
-		op := `{"op":"add","path":"attr2","value":1234}`
-		validator, err := NewValidator(op, patchSchema)
-		if err != nil {
-			t.Errorf("unexpected error, got %v", err)
-			return
+		ops := []string{
+			`{"op":"add","path":"attr2","value":1234}`,
+			`{"op":"add","path":"attr2","value":"1234"}`,
 		}
-		v, err := validator.Validate()
-		if err != nil {
-			t.Errorf("unexpected error, got %v", err)
-			return
-		}
-		n, ok := v.(int64)
-		if !ok {
-			t.Errorf("unexpected type, got %T", v)
-			return
-		}
-		if n != 1234 {
-			t.Errorf("unexpected integer, got %d", n)
-			return
+		for _, op := range ops {
+			validator, err := NewValidator(op, patchSchema)
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			v, err := validator.Validate()
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			n, ok := v.(int64)
+			if !ok {
+				t.Errorf("unexpected type, got %T", v)
+				return
+			}
+			if n != 1234 {
+				t.Errorf("unexpected integer, got %d", n)
+				return
+			}
 		}
 	})
 
 	t.Run("Valid float64", func(t *testing.T) {
-		op := `{"op":"add","path":"attr3","value":12.34}`
-		validator, err := NewValidator(op, patchSchema)
-		if err != nil {
-			t.Errorf("unexpected error, got %v", err)
-			return
+		ops := []string{
+			`{"op":"add","path":"attr3","value":12.34}`,
+			`{"op":"add","path":"attr3","value":"12.34"}`,
 		}
-		v, err := validator.Validate()
-		if err != nil {
-			t.Errorf("unexpected error, got %v", err)
-			return
+		for _, op := range ops {
+			validator, err := NewValidator(op, patchSchema)
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			v, err := validator.Validate()
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			n, ok := v.(float64)
+			if !ok {
+				t.Errorf("unexpected type, got %T", v)
+				return
+			}
+			if n != 12.34 {
+				t.Errorf("unexpected integer, got %f", n)
+				return
+			}
 		}
-		n, ok := v.(float64)
-		if !ok {
-			t.Errorf("unexpected type, got %T", v)
-			return
+	})
+
+	t.Run("Valid Booleans", func(t *testing.T) {
+		tests := []struct {
+			op       string
+			expected bool
+		}{
+			{`{"op":"add","path":"attr4","value":true}`, true},
+			{`{"op":"add","path":"attr4","value":"True"}`, true},
+			{`{"op":"add","path":"attr4","value":false}`, false},
+			{`{"op":"add","path":"attr4","value":"False"}`, false},
 		}
-		if n != 12.34 {
-			t.Errorf("unexpected integer, got %f", n)
-			return
+		for _, tc := range tests {
+			validator, err := NewValidator(tc.op, patchSchema)
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			v, err := validator.Validate()
+			if err != nil {
+				t.Errorf("unexpected error, got %v", err)
+				return
+			}
+			b, ok := v.(bool)
+			if !ok {
+				t.Errorf("unexpected type, got %T", v)
+				return
+			}
+			if b != tc.expected {
+				t.Errorf("unexpected integer, got %v", b)
+				return
+			}
 		}
 	})
 }

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -2,9 +2,10 @@ package patch
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/elimity-com/scim/schema"
 	"github.com/scim2/filter-parser/v2"
-	"testing"
 )
 
 func TestNewPathValidator(t *testing.T) {
@@ -29,6 +30,51 @@ func TestNewPathValidator(t *testing.T) {
 		op := `{"op":"add","path":"invalid pr","value":"value"}`
 		if _, err := NewValidator(op, patchSchema); err == nil {
 			t.Error("expected JSON error, got none")
+		}
+	})
+	t.Run("Valid integer", func(t *testing.T) {
+		op := `{"op":"add","path":"attr2","value":1234}`
+		validator, err := NewValidator(op, patchSchema)
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		v, err := validator.Validate()
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		n, ok := v.(int64)
+		if !ok {
+			t.Errorf("unexpected type, got %T", v)
+			return
+		}
+		if n != 1234 {
+			t.Errorf("unexpected integer, got %d", n)
+			return
+		}
+	})
+
+	t.Run("Valid float64", func(t *testing.T) {
+		op := `{"op":"add","path":"attr3","value":12.34}`
+		validator, err := NewValidator(op, patchSchema)
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		v, err := validator.Validate()
+		if err != nil {
+			t.Errorf("unexpected error, got %v", err)
+			return
+		}
+		n, ok := v.(float64)
+		if !ok {
+			t.Errorf("unexpected type, got %T", v)
+			return
+		}
+		if n != 12.34 {
+			t.Errorf("unexpected integer, got %f", n)
+			return
 		}
 	})
 }

--- a/internal/patch/remove_test.go
+++ b/internal/patch/remove_test.go
@@ -31,18 +31,6 @@ func Example_removeComplexMultiValuedAttributeValue() {
 	// <nil> <nil>
 }
 
-// The following example shows how remove a single member from a group.
-func Example_removeSingleMember() {
-	operation := `{
-	"op": "remove",
-	"path": "members[value eq \"0001\"]"
-}`
-	validator, _ := NewValidator(operation, schema.CoreGroupSchema())
-	fmt.Println(validator.Validate())
-	// Output:
-	// <nil> <nil>
-}
-
 // The following example shows how remove a single group from a user.
 func Example_removeSingleGroup() {
 	operation := `{
@@ -57,6 +45,18 @@ func Example_removeSingleGroup() {
 	fmt.Println(validator.Validate())
 	// Output:
 	// [map[]] <nil>
+}
+
+// The following example shows how remove a single member from a group.
+func Example_removeSingleMember() {
+	operation := `{
+	"op": "remove",
+	"path": "members[value eq \"0001\"]"
+}`
+	validator, _ := NewValidator(operation, schema.CoreGroupSchema())
+	fmt.Println(validator.Validate())
+	// Output:
+	// <nil> <nil>
 }
 
 // The following example shows how to replace all of the members of a group with a different members list.

--- a/internal/patch/schema_test.go
+++ b/internal/patch/schema_test.go
@@ -14,6 +14,14 @@ var (
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name: "attr1",
 			})),
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr2",
+				Type: schema.AttributeTypeInteger(),
+			})),
+			schema.SimpleCoreAttribute(schema.SimpleNumberParams(schema.NumberParams{
+				Name: "attr3",
+				Type: schema.AttributeTypeDecimal(),
+			})),
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name:        "multiValued",
 				MultiValued: true,

--- a/internal/patch/schema_test.go
+++ b/internal/patch/schema_test.go
@@ -22,6 +22,9 @@ var (
 				Name: "attr3",
 				Type: schema.AttributeTypeDecimal(),
 			})),
+			schema.SimpleCoreAttribute(schema.SimpleBooleanParams(schema.BooleanParams{
+				Name: "attr4",
+			})),
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name:        "multiValued",
 				MultiValued: true,

--- a/schema/core.go
+++ b/schema/core.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	datetime "github.com/di-wu/xsd-datetime"
@@ -179,12 +180,19 @@ func (a CoreAttribute) ValidateSingular(attribute interface{}) (interface{}, *er
 
 		return bin, nil
 	case attributeDataTypeBoolean:
-		b, ok := attribute.(bool)
-		if !ok {
+		switch b := attribute.(type) {
+		case bool:
+			return b, nil
+		case string:
+			bb, err := strconv.ParseBool(b)
+			if err != nil {
+				return nil, &errors.ScimErrorInvalidValue
+			}
+
+			return bb, nil
+		default:
 			return nil, &errors.ScimErrorInvalidValue
 		}
-
-		return b, nil
 	case attributeDataTypeComplex:
 		obj, ok := attribute.(map[string]interface{})
 		if !ok {
@@ -237,6 +245,13 @@ func (a CoreAttribute) ValidateSingular(attribute interface{}) (interface{}, *er
 			return f, nil
 		case float64:
 			return n, nil
+		case string:
+			f, err := strconv.ParseFloat(n, 64)
+			if err != nil {
+				return nil, &errors.ScimErrorInvalidValue
+			}
+
+			return f, nil
 		default:
 			return nil, &errors.ScimErrorInvalidValue
 		}
@@ -251,6 +266,13 @@ func (a CoreAttribute) ValidateSingular(attribute interface{}) (interface{}, *er
 			return i, nil
 		case int, int8, int16, int32, int64:
 			return n, nil
+		case string:
+			i, err := strconv.ParseInt(n, 10, 64)
+			if err != nil {
+				return nil, &errors.ScimErrorInvalidValue
+			}
+
+			return i, nil
 		default:
 			return nil, &errors.ScimErrorInvalidValue
 		}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -229,7 +229,7 @@ func TestValidationInvalid(t *testing.T) {
 			"booleans": []interface{}{
 				true,
 			},
-			"decimal": "1.1",
+			"decimal": "1,000",
 		},
 		{ // invalid type integer (json.Number)
 			"required": "present",


### PR DESCRIPTION
### Description

This commit makes validating integers, decimals, and booleans more
flexible. Some SCIM clients, like the one used in Microsoft Azure, will
send numbers as strings, and by default, the "active" attribute on
a PATCH will also be a string like "False".

This PR is built on top of https://github.com/elimity-com/scim/pull/164, which allows using integer attributes in patches.