### PR TITLE
Add Support for custom attributes

### DIFF
--- a/resource_type.go
+++ b/resource_type.go
@@ -36,6 +36,9 @@ type ResourceType struct {
 
 	// Handler is the set of callback method that connect the SCIM server with a provider of the resource type.
 	Handler ResourceHandler
+
+	// AllowNonScimKeys is a flag to allow non scim complaint attributes to be part of the resource type
+	AllowNonScimKeys bool
 }
 
 func (t ResourceType) getRaw() map[string]interface{} {
@@ -112,6 +115,14 @@ func (t ResourceType) validate(raw []byte) (ResourceAttributes, *errors.ScimErro
 		}
 
 		attributes[extension.Schema.ID] = extensionAttributes
+	}
+	// add all the keys from the original map that are not in the schema
+	if t.AllowNonScimKeys {
+		for k, v := range m {
+			if _, ok := attributes[k]; !ok {
+				attributes[k] = v
+			}
+		}
 	}
 
 	return attributes, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -96,3 +96,20 @@ func getLen(x interface{}) (ok bool, length int) {
 	}()
 	return true, v.Len()
 }
+
+func assertEqualMaps(t *testing.T, map1, map2 map[string]interface{}) {
+	if len(map1) != len(map2) {
+		t.Errorf("Maps have different lengths: %d != %d", len(map1), len(map2))
+	}
+
+	for key, value1 := range map1 {
+		value2, ok := map2[key]
+		if !ok {
+			t.Errorf("Key %s not found in map2", key)
+		}
+
+		if !reflect.DeepEqual(value1, value2) {
+			t.Errorf("Values for key %s are different: %v != %v", key, value1, value2)
+		}
+	}
+}


### PR DESCRIPTION
Issue
IDP like OKTA, Azure support custom attributes along with scim attributes. Today Resource type validations will drop all non-scim compliant attributes during validation

Solution
Adding a flag to allow non-SCIM compliant attributes, updating the validation logic to include these attributes

Support for custom attributes:

* [`resource_type.go`](diffhunk://#diff-7efd1b322562208db3d3c78274d63e6ee6ca770759870758afd1829ee672cf0aR39-R41): Added `AllowNonScimKeys` flag to `ResourceType` to allow non-SCIM compliant attributes. Updated the `validate` method to include these attributes in the resource type. [[1]](diffhunk://#diff-7efd1b322562208db3d3c78274d63e6ee6ca770759870758afd1829ee672cf0aR39-R41) [[2]](diffhunk://#diff-7efd1b322562208db3d3c78274d63e6ee6ca770759870758afd1829ee672cf0aR119-R126)

Testing enhancements:

* [`handlers_test.go`](diffhunk://#diff-f3352cbd560f9467e98af5ecd129c7d1f43917302653fe5ceafbd8bc857f83c7R973): Added the `AllowNonScimKeys` flag to the `newTestServer` function and created a new test `TestServerResourceHandlerWithCustomAttributes` to verify the handling of custom attributes. [[1]](diffhunk://#diff-f3352cbd560f9467e98af5ecd129c7d1f43917302653fe5ceafbd8bc857f83c7R973) [[2]](diffhunk://#diff-f3352cbd560f9467e98af5ecd129c7d1f43917302653fe5ceafbd8bc857f83c7R1002-R1089)
* [`utils_test.go`](diffhunk://#diff-189b40dd496fee4378c7839f550f27e38db377a64fbe0881ce48651f0ac809faR99-R115): Added a helper function `assertEqualMaps` to compare maps in tests.