### PR TITLE
ensure all handlers respond with a status code, rather than rely on t…

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -66,7 +66,7 @@ func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id st
 	if resource.Meta.Version != "" {
 		w.Header().Set("Etag", resource.Meta.Version)
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -199,7 +199,7 @@ func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id st
 	if resource.Meta.Version != "" {
 		w.Header().Set("Etag", resource.Meta.Version)
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -235,7 +235,7 @@ func (s Server) resourceTypeHandler(w http.ResponseWriter, r *http.Request, name
 			"error", err,
 		)
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -277,7 +277,7 @@ func (s Server) resourceTypesHandler(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -319,7 +319,7 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 		)
 		return
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -403,7 +403,7 @@ func (s Server) schemasHandler(w http.ResponseWriter, r *http.Request) {
 		)
 		return
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(
@@ -426,7 +426,7 @@ func (s Server) serviceProviderConfigHandler(w http.ResponseWriter, r *http.Requ
 		)
 		return
 	}
-
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(raw)
 	if err != nil {
 		s.log.Error(


### PR DESCRIPTION
When wrapping the server handler with a logging middleware, e.g:

```go
type detailedResponseWriter struct {
	http.ResponseWriter
	statusCode int
}

func (dw *detailedResponseWriter) WriteHeader(code int) {
	dw.statusCode = code
	dw.ResponseWriter.WriteHeader(code)
}

func (dw *detailedResponseWriter) StatusCode() int {
	return dw.statusCode
}

func Logger(log *slog.Logger) func(next http.Handler) http.Handler {
	return func(next http.Handler) http.Handler {
		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			start := time.Now()
			dw := &detailedResponseWriter{ResponseWriter: w}
			next.ServeHTTP(dw, r)
			log.InfoContext(r.Context(), "request log",
				slog.String("method", r.Method),
				slog.String("request_uri", r.URL.Path),
				slog.Any("duration", time.Since(start)),
				slog.Int("status_code", dw.StatusCode()))
		})
	}
}
```

because most of the underlying handlers rely on the http.Server defaulting the status at the very end - it is not possible to correctly get the status for endpoints which return a status 200.

This change just ensures a consistently setting the http status from all handlers.